### PR TITLE
Add blacklist role management

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/Bot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Bot.java
@@ -264,7 +264,7 @@ public class Bot extends ListenerAdapter {
         writeSettings();
     }
 
-    public void setRole(Role role)
+    public void setBlacklistRole(Role role)
     {
         Settings s = settings.get(role.getGuild().getId());
         if(s==null)
@@ -273,10 +273,25 @@ public class Bot extends ListenerAdapter {
         }
         else
         {
-            s.setRoleId(role.getIdLong());
+            s.setBlacklistRole(role.getIdLong());
         }
         writeSettings();
     }
+
+    public void setDjRole(Role role)
+    {
+        Settings s = settings.get(role.getGuild().getId());
+        if(s==null)
+        {
+            settings.put(role.getGuild().getId(), new Settings(null,null,role.getId(),100,null));
+        }
+        else
+        {
+            s.setDjRole(role.getIdLong());
+        }
+        writeSettings();
+    }
+
 
     public void setDefaultPlaylist(Guild guild, String playlist)
     {
@@ -332,7 +347,7 @@ public class Bot extends ListenerAdapter {
         }
     }
 
-    public void clearRole(Guild guild)
+    public void clearBlacklistRole(Guild guild)
     {
         Settings s = getSettings(guild);
         if(s!=Settings.DEFAULT_SETTINGS)
@@ -340,7 +355,20 @@ public class Bot extends ListenerAdapter {
             if(s.getVoiceId()==0 && s.getTextId()==0)
                 settings.remove(guild.getId());
             else
-                s.setRoleId(0);
+                s.setBlacklistRole(0);
+            writeSettings();
+        }
+    }
+
+    public void clearDjRole(Guild guild)
+    {
+        Settings s = getSettings(guild);
+        if(s!=Settings.DEFAULT_SETTINGS)
+        {
+            if(s.getVoiceId()==0 && s.getTextId()==0)
+                settings.remove(guild.getId());
+            else
+                s.setDjRoleId(0);
             writeSettings();
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/Settings.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Settings.java
@@ -21,14 +21,15 @@ package com.jagrosh.jmusicbot;
  */
 public class Settings {
     public final static Settings DEFAULT_SETTINGS = new Settings(0, 0, 0, 100, null);
-    
+
     private long textId;
     private long voiceId;
-    private long roleId;
+    private long djRoleId;
+    private long blacklistRoleId;
     private int volume;
     private String defaultPlaylist;
-    
-    public Settings(String textId, String voiceId, String roleId, int volume, String defaultPlaylist)
+
+    public Settings(String textId, String voiceId, String djRoleId, String blacklistRoleId int volume, String defaultPlaylist)
     {
         try
         {
@@ -48,74 +49,93 @@ public class Settings {
         }
         try
         {
-            this.roleId = Long.parseLong(roleId);
+            this.djRoleId = Long.parseLong(djRoleId);
         }
         catch(NumberFormatException e)
         {
-            this.roleId = 0;
+            this.djRoleId = 0;
+        }
+        try
+        {
+            this.blacklistRoleId = Long.parseLong(blacklistRoleId);
+        }
+        catch(NumberFormatException e)
+        {
+            this.blacklistRoleId = 0;
         }
         this.volume = volume;
         this.defaultPlaylist = defaultPlaylist;
     }
-    
-    public Settings(long textId, long voiceId, long roleId, int volume, String defaultPlaylist)
+
+    public Settings(long textId, long voiceId, long roleId, long blacklistRoleId, int volume, String defaultPlaylist)
     {
         this.textId = textId;
         this.voiceId = voiceId;
-        this.roleId = roleId;
+        this.djRoleId = djRoleId;
+        this.blacklistRoleId = blacklistRoleId;
         this.volume = volume;
         this.defaultPlaylist = defaultPlaylist;
     }
-    
+
     public long getTextId()
     {
         return textId;
     }
-    
+
     public long getVoiceId()
     {
         return voiceId;
     }
-    
-    public long getRoleId()
+
+    public long getDjRoleId()
     {
-        return roleId;
+        return djRoleId;
     }
-    
+
+    public long getBlacklistRoleId()
+    {
+        return blacklistRoleId;
+    }
+
     public int getVolume()
     {
         return volume;
     }
-    
+
     public String getDefaultPlaylist()
     {
         return defaultPlaylist;
     }
-    
+
     public void setTextId(long id)
     {
         this.textId = id;
     }
-    
+
     public void setVoiceId(long id)
     {
         this.voiceId = id;
     }
-    
-    public void setRoleId(long id)
+
+    public void setDjRoleId(long id)
     {
-        this.roleId = id;
+        this.djRoleId = id;
     }
-    
+
+    public void setBlacklistRoleId(long id)
+    {
+        this.blacklistRoleId = id;
+    }
+
     public void setVolume(int volume)
     {
         this.volume = volume;
     }
-    
+
     public void setDefaultPlaylist(String defaultPlaylist)
     {
         this.defaultPlaylist = defaultPlaylist;
     }
-    
-    
+
+
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/RemoveCmd.java
@@ -70,7 +70,7 @@ public class RemoveCmd extends MusicCommand {
         }
         boolean isDJ = event.getMember().hasPermission(Permission.MANAGE_SERVER);
         if(!isDJ)
-            isDJ = event.getMember().getRoles().contains(event.getGuild().getRoleById(bot.getSettings(event.getGuild()).getRoleId()));
+            isDJ = event.getMember().getRoles().contains(event.getGuild().getRoleById(bot.getSettings(event.getGuild()).getDjRoleId()));
         QueuedTrack qt = handler.getQueue().get(pos-1);
         if(qt.getIdentifier().equals(event.getAuthor().getId()))
         {
@@ -94,5 +94,5 @@ public class RemoveCmd extends MusicCommand {
             event.reply(event.getClient().getError()+" You cannot remove **"+qt.getTrack().getInfo().title+"** because you didn't add it!");
         }
     }
-    
+
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/SetblacklistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/SetblacklistCmd.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands;
+
+import java.util.List;
+import com.jagrosh.jdautilities.commandclient.Command;
+import com.jagrosh.jdautilities.commandclient.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.utils.FinderUtil;
+import com.jagrosh.jmusicbot.utils.FormatUtil;
+import net.dv8tion.jda.core.entities.Role;
+
+/**
+ *
+ * @author John Grosh <john.a.grosh@gmail.com>
+ */
+public class SetblacklistCmd extends Command {
+
+    private final Bot bot;
+    public SetblacklistCmd(Bot bot)
+    {
+        this.bot = bot;
+        this.name = "setblacklist";
+        this.help = "sets the blacklist role for certain music commands";
+        this.arguments = "<rolename|NONE>";
+        this.guildOnly = true;
+        this.category = bot.ADMIN;
+    }
+
+    @Override
+    protected void execute(CommandEvent event) {
+        if(event.getArgs().isEmpty())
+        {
+            event.reply(event.getClient().getError()+" Please include a role name or NONE");
+        }
+        else if(event.getArgs().equalsIgnoreCase("none"))
+        {
+            bot.clearTextChannel(event.getGuild());
+            event.reply(event.getClient().getSuccess()+" Blacklist role cleared; All users can use music commands");
+        }
+        else
+        {
+            List<Role> list = FinderUtil.findRole(event.getArgs(), event.getGuild());
+            if(list.isEmpty())
+                event.reply(event.getClient().getWarning()+" No Roles found matching \""+event.getArgs()+"\"");
+            else if (list.size()>1)
+                event.reply(event.getClient().getWarning()+FormatUtil.listOfRoles(list, event.getArgs()));
+            else
+            {
+                bot.setRole(list.get(0));
+                event.reply(event.getClient().getSuccess()+" standard music commands can now only be used by users without the **"+list.get(0).getName()+"** role.");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/SetblacklistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/SetblacklistCmd.java
@@ -60,7 +60,7 @@ public class SetblacklistCmd extends Command {
                 event.reply(event.getClient().getWarning()+FormatUtil.listOfRoles(list, event.getArgs()));
             else
             {
-                bot.setRole(list.get(0));
+                bot.setBlacklistRole(list.get(0));
                 event.reply(event.getClient().getSuccess()+" standard music commands can now only be used by users without the **"+list.get(0).getName()+"** role.");
             }
         }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/SetdjCmd.java
@@ -39,7 +39,7 @@ public class SetdjCmd extends Command {
         this.guildOnly = true;
         this.category = bot.ADMIN;
     }
-    
+
     @Override
     protected void execute(CommandEvent event) {
         if(event.getArgs().isEmpty())
@@ -60,10 +60,10 @@ public class SetdjCmd extends Command {
                 event.reply(event.getClient().getWarning()+FormatUtil.listOfRoles(list, event.getArgs()));
             else
             {
-                bot.setRole(list.get(0));
+                bot.setDjRole(list.get(0));
                 event.reply(event.getClient().getSuccess()+" DJ commands can now be used by users with the **"+list.get(0).getName()+"** role.");
             }
         }
     }
-    
+
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/SettingsCmd.java
@@ -40,7 +40,7 @@ public class SettingsCmd extends Command {
         this.aliases = new String[]{"status"};
         this.guildOnly = true;
     }
-    
+
     @Override
     protected void execute(CommandEvent event) {
         Settings s = bot.getSettings(event.getGuild());
@@ -50,7 +50,7 @@ public class SettingsCmd extends Command {
                 .append("** settings:");
         TextChannel tchan = event.getGuild().getTextChannelById(s.getTextId());
         VoiceChannel vchan = event.getGuild().getVoiceChannelById(s.getVoiceId());
-        Role role = event.getGuild().getRoleById(s.getRoleId());
+        Role role = event.getGuild().getRoleById(s.getDjRoleId());
         EmbedBuilder ebuilder = new EmbedBuilder()
                 .setColor(event.getSelfMember().getColor())
                 .setDescription("Text Channel: "+(tchan==null ? "Any" : "**#"+tchan.getName()+"**")
@@ -63,5 +63,5 @@ public class SettingsCmd extends Command {
                         +" audio connections", null);
         event.getChannel().sendMessage(builder.setEmbed(ebuilder.build()).build()).queue();
     }
-    
+
 }


### PR DESCRIPTION
This is to resolve #28.
* Add a new role to Settings for blacklist
* Users on with this role cannot use any of the bot's commands
* DJs and Admins with the role can still use the bot's commands
* A `setblacklist` command was added to configure this at runtime.

I have not 100% tested this functionality yet due to lack of a fully set up development environment. Please notify me of any breakages that are caused by this change.

TODO: Instead of creating multiple commands for each role used, utilize a enum instead and pass it as a parameter.