### PR TITLE
Option to prevent joining voice channels when another bot is present

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/Bot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Bot.java
@@ -116,7 +116,8 @@ public class Bot extends ListenerAdapter {
                         o.has("dj_role_id")      ? o.getString("dj_role_id")      : null,
                         o.has("volume")          ? o.getInt("volume")             : 100,
                         o.has("default_playlist")? o.getString("default_playlist"): null,
-                        o.has("repeat")          ? o.getBoolean("repeat")         : false));
+                        o.has("repeat")          ? o.getBoolean("repeat")         : false,
+                        o.has("avoidOtherBots")  ? o.getBoolean("avoidOtherBots") : false));
             });
         } catch(IOException | JSONException e) {
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
@@ -328,7 +329,7 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(channel.getGuild().getId());
         if(s==null)
         {
-            settings.put(channel.getGuild().getId(), new Settings(channel.getId(),null,null,100,null,false));
+            settings.put(channel.getGuild().getId(), new Settings(channel.getId(),null,null,100,null,false, false));
         }
         else
         {
@@ -342,7 +343,7 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(channel.getGuild().getId());
         if(s==null)
         {
-            settings.put(channel.getGuild().getId(), new Settings(null,channel.getId(),null,100,null,false));
+            settings.put(channel.getGuild().getId(), new Settings(null,channel.getId(),null,100,null,false, false));
         }
         else
         {
@@ -356,7 +357,7 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(role.getGuild().getId());
         if(s==null)
         {
-            settings.put(role.getGuild().getId(), new Settings(null,null,role.getId(),100,null,false));
+            settings.put(role.getGuild().getId(), new Settings(null,null,role.getId(),100,null,false, false));
         }
         else
         {
@@ -370,7 +371,7 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(guild.getId());
         if(s==null)
         {
-            settings.put(guild.getId(), new Settings(null,null,null,100,playlist,false));
+            settings.put(guild.getId(), new Settings(null,null,null,100,playlist,false, false));
         }
         else
         {
@@ -384,7 +385,7 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(guild.getId());
         if(s==null)
         {
-            settings.put(guild.getId(), new Settings(null,null,null,volume,null,false));
+            settings.put(guild.getId(), new Settings(null,null,null,volume,null,false, false));
         }
         else
         {
@@ -398,11 +399,25 @@ public class Bot extends ListenerAdapter {
         Settings s = settings.get(guild.getId());
         if(s==null)
         {
-            settings.put(guild.getId(), new Settings(null,null,null,100,null,mode));
+            settings.put(guild.getId(), new Settings(null,null,null,100,null,mode, false));
         }
         else
         {
             s.setRepeatMode(mode);
+        }
+        writeSettings();
+    }
+
+    public void setAvoidBots(Guild guild, boolean mode)
+    {
+        Settings s = settings.get(guild.getId());
+        if(s==null)
+        {
+            settings.put(guild.getId(), new Settings(null,null,null,100,null,false, mode));
+        }
+        else
+        {
+            s.setAvoidOtherBots(mode);
         }
         writeSettings();
     }
@@ -464,6 +479,8 @@ public class Bot extends ListenerAdapter {
                 o.put("default_playlist", s.getDefaultPlaylist());
             if(s.getRepeatMode())
                 o.put("repeat", true);
+            if (s.getAvoidOtherBots())
+                o.put("avoidOtherBots", true);
             obj.put(key, o);
         });
         try {

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -138,6 +138,7 @@ public class JMusicBot
                         new SetdjCmd(bot),
                         new SettcCmd(bot),
                         new SetvcCmd(bot),
+                        new AvoidBotsCmd(bot),
                         
                         //new GuildlistCommand(waiter),
                         new AutoplaylistCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/Settings.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Settings.java
@@ -20,7 +20,7 @@ package com.jagrosh.jmusicbot;
  * @author John Grosh <john.a.grosh@gmail.com>
  */
 public class Settings {
-    public final static Settings DEFAULT_SETTINGS = new Settings(0, 0, 0, 100, null, false);
+    public final static Settings DEFAULT_SETTINGS = new Settings(0, 0, 0, 100, null, false, false);
     
     private long textId;
     private long voiceId;
@@ -28,8 +28,9 @@ public class Settings {
     private int volume;
     private String defaultPlaylist;
     private boolean repeatMode;
+    private boolean avoidOtherBots;
     
-    public Settings(String textId, String voiceId, String roleId, int volume, String defaultPlaylist, boolean repeatMode)
+    public Settings(String textId, String voiceId, String roleId, int volume, String defaultPlaylist, boolean repeatMode, boolean avoidOtherBots)
     {
         try
         {
@@ -58,9 +59,10 @@ public class Settings {
         this.volume = volume;
         this.defaultPlaylist = defaultPlaylist;
         this.repeatMode = repeatMode;
+        this.avoidOtherBots = avoidOtherBots;
     }
     
-    public Settings(long textId, long voiceId, long roleId, int volume, String defaultPlaylist, boolean repeatMode)
+    public Settings(long textId, long voiceId, long roleId, int volume, String defaultPlaylist, boolean repeatMode, boolean avoidOtherBots)
     {
         this.textId = textId;
         this.voiceId = voiceId;
@@ -68,6 +70,7 @@ public class Settings {
         this.volume = volume;
         this.defaultPlaylist = defaultPlaylist;
         this.repeatMode = repeatMode;
+        this.avoidOtherBots = avoidOtherBots;
     }
     
     public long getTextId()
@@ -128,5 +131,15 @@ public class Settings {
     public void setRepeatMode(boolean mode)
     {
         this.repeatMode = mode;
+    }
+
+    public boolean getAvoidOtherBots()
+    {
+        return this.avoidOtherBots;
+    }
+
+    public void setAvoidOtherBots(boolean avoidOtherBots)
+    {
+        this.avoidOtherBots = avoidOtherBots;
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/AvoidBotsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/AvoidBotsCmd.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+
+public class AvoidBotsCmd extends Command {
+
+    private final Bot bot;
+    public AvoidBotsCmd(Bot bot)
+    {
+        this.bot = bot;
+        this.name = "avoidbots";
+        this.help = "prevents joining a voice channel when another bot is detected";
+        this.arguments = "[on|off]";
+        this.guildOnly = true;
+        this.category = bot.OWNER;
+        this.ownerCommand = true;
+    }
+    
+    @Override
+    protected void execute(CommandEvent event) {
+        boolean value;
+        if(event.getArgs().isEmpty())
+        {
+            value = !bot.getSettings(event.getGuild()).getAvoidOtherBots();
+        }
+        else if(event.getArgs().equalsIgnoreCase("true") || event.getArgs().equalsIgnoreCase("on"))
+        {
+            value = true;
+        }
+        else if(event.getArgs().equalsIgnoreCase("false") || event.getArgs().equalsIgnoreCase("off"))
+        {
+            value = false;
+        }
+        else
+        {
+            event.replyError("Valid options are `on` or `off` (or leave empty to toggle)");
+            return;
+        }
+        bot.setAvoidBots(event.getGuild(), value);
+        event.replySuccess("Avoid bots mode is now `"+(value ? "ON" : "OFF")+"`");
+    }
+    
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -21,9 +21,12 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.Settings;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import net.dv8tion.jda.core.entities.GuildVoiceState;
+import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.exceptions.PermissionException;
+
+import java.util.Optional;
 
 /**
  *
@@ -76,6 +79,13 @@ public abstract class MusicCommand extends Command {
             }
             if(!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel())
                 try {
+                    if (settings.getAvoidOtherBots()) {
+                        Optional<Member> otherBot = userState.getChannel().getMembers().stream().filter(m -> m.getUser().isBot()).findFirst();
+                        if (otherBot.isPresent()) {
+                            event.reply(event.getClient().getError() + " I am unable to connect to **"+userState.getChannel().getName()+"**; another bot detected");
+                            return;
+                        }
+                    }
                     event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
                 }catch(PermissionException ex) {
                     event.reply(event.getClient().getError()+" I am unable to connect to **"+userState.getChannel().getName()+"**!");


### PR DESCRIPTION
On our server we have multiple music bots and sometimes people use the wrong command and we end up with 2 in the channel, this just provides an option to bail if another member of the target voice channel is a bot.