### PR TITLE
Move track command

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -114,11 +114,11 @@ public class JMusicBot
                         new SkipCmd(bot),
                         
                         new ForceskipCmd(bot),
+                        new MoveTrackCmd(bot),
                         new PauseCmd(bot),
                         new PlaynextCmd(bot, config.getLoading()),
                         new RepeatCmd(bot),
                         new SkiptoCmd(bot),
-                        new MoveTrackCmd(bot),
                         new StopCmd(bot),
                         new VolumeCmd(bot),
                         

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -118,6 +118,7 @@ public class JMusicBot
                         new PlaynextCmd(bot, config.getLoading()),
                         new RepeatCmd(bot),
                         new SkiptoCmd(bot),
+                        new MoveTrackCmd(bot),
                         new StopCmd(bot),
                         new VolumeCmd(bot),
                         

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -33,7 +33,7 @@ public class MoveTrackCmd extends DJCommand
         String[] parts = event.getArgs().split("\\s+", 2);
         if(parts.length < 2)
         {
-            event.replyError("Please include two valid indexes.'");
+            event.replyError("Please include two valid indexes.");
             return;
         }
 
@@ -74,7 +74,7 @@ public class MoveTrackCmd extends DJCommand
         // Move the track
         QueuedTrack track = queue.moveItem(from - 1, to - 1);
         String trackTitle = track.getTrack().getInfo().title;
-        String reply = String.format("Moved **%s** from position `%d` to `%d.`", trackTitle, from, to);
+        String reply = String.format("Moved **%s** from position `%d` to `%d`.", trackTitle, from, to);
         event.replySuccess(reply);
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -1,0 +1,92 @@
+package com.jagrosh.jmusicbot.commands.dj;
+
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.audio.AudioHandler;
+import com.jagrosh.jmusicbot.audio.QueuedTrack;
+import com.jagrosh.jmusicbot.commands.DJCommand;
+import com.jagrosh.jmusicbot.queue.FairQueue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Command that provides users the ability to move a track in the playlist.
+ */
+public class MoveTrackCmd extends DJCommand
+{
+
+    private static final Pattern PATTERN = Pattern.compile("^(\\d+)\\s+(\\d+)$");
+
+    public MoveTrackCmd(Bot bot)
+    {
+        super(bot);
+        this.name = "movetrack";
+        this.help = "Move a track in the current playlist to a different position";
+        this.arguments = "<from> <to>";
+        this.aliases = new String[]{"move"};
+        this.bePlaying = true;
+    }
+
+    @Override
+    public void doCommand(CommandEvent event)
+    {
+        int from;
+        int to;
+
+        try
+        {
+            // Validate the args
+            String args = event.getArgs().trim();
+            Matcher matcher = PATTERN.matcher(args);
+            if (!matcher.matches())
+            {
+                event.replyError("That ain't right. Usage: movetrack <from> <to>");
+                return;
+            }
+
+            from = Integer.parseInt(matcher.group(1));
+            to = Integer.parseInt(matcher.group(2));
+        }
+        catch (NumberFormatException e)
+        {
+            // Should already be caught by the regex but ok..
+            event.replyError("That ain't a number: " + e.getMessage());
+            return;
+        }
+
+        if (from == to)
+        {
+            event.replySuccess("Wow! That was easy. Great job using this command. You're doing a great job.");
+            return;
+        }
+
+        // Validate that these are both positions available
+        AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
+        FairQueue<QueuedTrack> queue = handler.getQueue();
+        if (!isAvailablePosition(event, queue, from) || !isAvailablePosition(event, queue, to))
+        {
+            return;
+        }
+
+        // Move the track
+        QueuedTrack track = queue.moveItem(from - 1, to - 1);
+        String trackTitle = track.getTrack().getInfo().title;
+        String reply = String.format("Moved track '%s' from position %d to %d.", trackTitle, from, to);
+        event.replySuccess(reply);
+    }
+
+    private boolean isAvailablePosition(CommandEvent event, FairQueue<QueuedTrack> queue, int position)
+    {
+        if (position < 1 || position > queue.size())
+        {
+            event.replyError(position + " ain't a valid position.");
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -8,22 +8,17 @@ import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.queue.FairQueue;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Command that provides users the ability to move a track in the playlist.
  */
 public class MoveTrackCmd extends DJCommand
 {
 
-    private static final Pattern PATTERN = Pattern.compile("^(\\d+)\\s+(\\d+)$");
-
     public MoveTrackCmd(Bot bot)
     {
         super(bot);
         this.name = "movetrack";
-        this.help = "Move a track in the current playlist to a different position";
+        this.help = "move a track in the current queue to a different position";
         this.arguments = "<from> <to>";
         this.aliases = new String[]{"move"};
         this.bePlaying = true;
@@ -35,58 +30,56 @@ public class MoveTrackCmd extends DJCommand
         int from;
         int to;
 
+        String[] parts = event.getArgs().split("\\s+", 2);
+        if(parts.length < 2)
+        {
+            event.replyError("Please include two valid indexes.'");
+            return;
+        }
+
         try
         {
             // Validate the args
-            String args = event.getArgs().trim();
-            Matcher matcher = PATTERN.matcher(args);
-            if (!matcher.matches())
-            {
-                event.replyError("That ain't right. Usage: movetrack <from> <to>");
-                return;
-            }
-
-            from = Integer.parseInt(matcher.group(1));
-            to = Integer.parseInt(matcher.group(2));
+            from = Integer.parseInt(parts[0]);
+            to = Integer.parseInt(parts[1]);
         }
         catch (NumberFormatException e)
         {
-            // Should already be caught by the regex but ok..
-            event.replyError("That ain't a number: " + e.getMessage());
+            event.replyError("Please provide two valid indexes.");
             return;
         }
 
         if (from == to)
         {
-            event.replySuccess("Wow! That was easy. Great job using this command. You're doing a great job.");
+            event.replyError("Can't move a track to the same position.");
             return;
         }
 
-        // Validate that these are both positions available
+        // Validate that from and to are available
         AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
         FairQueue<QueuedTrack> queue = handler.getQueue();
-        if (!isAvailablePosition(event, queue, from) || !isAvailablePosition(event, queue, to))
+        if (isUnavailablePosition(queue, from))
         {
+            String reply = String.format("`%d` is not a valid position in the queue!", from);
+            event.replyError(reply);
+            return;
+        }
+        if (isUnavailablePosition(queue, to))
+        {
+            String reply = String.format("`%d` is not a valid position in the queue!", to);
+            event.replyError(reply);
             return;
         }
 
         // Move the track
         QueuedTrack track = queue.moveItem(from - 1, to - 1);
         String trackTitle = track.getTrack().getInfo().title;
-        String reply = String.format("Moved track '%s' from position %d to %d.", trackTitle, from, to);
+        String reply = String.format("Moved **%s** from position `%d` to `%d.`", trackTitle, from, to);
         event.replySuccess(reply);
     }
 
-    private boolean isAvailablePosition(CommandEvent event, FairQueue<QueuedTrack> queue, int position)
+    private static boolean isUnavailablePosition(FairQueue<QueuedTrack> queue, int position)
     {
-        if (position < 1 || position > queue.size())
-        {
-            event.replyError(position + " ain't a valid position.");
-            return false;
-        }
-        else
-        {
-            return true;
-        }
+        return (position < 1 || position > queue.size());
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
@@ -128,4 +128,17 @@ public class FairQueue<T extends Queueable> {
         for(int i=0; i<number; i++)
             list.remove(0);
     }
+
+    /**
+     * Move an item to a different position in the list
+     * @param from The position of the item
+     * @param to The new position of the item
+     * @return the moved item
+     */
+    public T moveItem(int from, int to)
+    {
+        T item = list.remove(from);
+        list.add(to, item);
+        return item;
+    }
 }


### PR DESCRIPTION
Adds support for moving a track in queue.

### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Adds `?movetrack <from> <to>` command to move the queued item `<from>` to the specified position `<to>`.

### Purpose
Adds more control to the queue. Implemented as DJ command.


### Notes from the author
Implemented this in my own fork which uses a different code style (braces etc). I manually tried to get it in line with the upstream (your) repository, but an automated refactor might be wise.

