### PR TITLE
Added ForceRemoveCmd

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -112,7 +112,8 @@ public class JMusicBot
                         new SCSearchCmd(bot, config.getSearching()),
                         new ShuffleCmd(bot),
                         new SkipCmd(bot),
-                        
+
+                        new ForceRemoveCmd(bot),
                         new ForceskipCmd(bot),
                         new MoveTrackCmd(bot),
                         new PauseCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -2,6 +2,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
+import com.jagrosh.jdautilities.menu.OrderedMenu;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
@@ -51,7 +52,36 @@ public class ForceRemoveCmd extends DJCommand
         }
         else if(found.size()>1)
         {
-            event.replyWarning("Found multiple users!");
+            OrderedMenu.Builder builder = new OrderedMenu.Builder();
+            for(int i=0; i<found.size() && i<4; i++)
+            {
+                Member member = found.get(i);
+                builder.addChoice("**"+member.getUser().getName()+"**#"+member.getUser().getDiscriminator());
+            }
+
+            builder.setSelection((msg, i) ->
+            {
+                User selectedUser = found.get(i-1).getUser();
+                int count = handler.getQueue().removeAll(selectedUser.getIdLong());
+                if (count == 0)
+                {
+                    event.replyWarning("**"+selectedUser.getName()+"** doesn't have any songs in the queue!");
+                }
+                else
+                {
+                    event.replySuccess("Successfully removed `"+count+"` entries from **"+selectedUser.getName()+"**#"+selectedUser.getDiscriminator()+".");
+                }
+            })
+            .setText("Found multiple users:")
+            .setColor(event.getSelfMember().getColor())
+            .useNumbers()
+            .setUsers(event.getAuthor())
+            .useCancelButton(true)
+            .setCancel((msg) -> {})
+            .setEventWaiter(bot.getWaiter())
+
+            .build().display(event.getChannel());
+
             return;
         }
         else
@@ -67,7 +97,7 @@ public class ForceRemoveCmd extends DJCommand
         }
         else
         {
-                event.replySuccess("Successfully removed `" + count + "` entries from **" + target.getName() + "**#" + target.getDiscriminator() + ".");
+            event.replySuccess("Successfully removed `"+count+"` entries from **"+target.getName()+"**#"+target.getDiscriminator()+".");
         }
 
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -43,10 +43,7 @@ public class ForceRemoveCmd extends MusicCommand {
         } else {
             try {
                 target = Long.parseLong(args);
-            } catch (NumberFormatException ignored) {
-                event.replyError("You need to mention a user!");
-                return;
-            }
+            } catch (NumberFormatException ignored) {}
         }
         if (target <= 0) {
             event.replyError("You need to mention a user!");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -93,7 +93,7 @@ public class ForceRemoveCmd extends DJCommand
         int count = handler.getQueue().removeAll(target.getIdLong());
         if (count == 0)
         {
-            event.replyWarning(target.getName() + " doesn't have any songs in the queue!");
+            event.replyWarning("**"+target.getName()+"** doesn't have any songs in the queue!");
         }
         else
         {

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -1,60 +1,74 @@
 package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.commons.utils.FinderUtil;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
-import com.jagrosh.jmusicbot.commands.MusicCommand;
+import com.jagrosh.jmusicbot.commands.DJCommand;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.User;
+
+import java.util.List;
 
 
-public class ForceRemoveCmd extends MusicCommand {
-    public ForceRemoveCmd(Bot bot) {
+public class ForceRemoveCmd extends DJCommand
+{
+    public ForceRemoveCmd(Bot bot)
+    {
         super(bot);
         this.name = "forceremove";
-        this.help = "removes all entries by the mentioned user from the queue";
-        this.arguments = "<@user|id>";
-        this.aliases = new String[]{"forcedelete"};
-        this.beListening = true;
+        this.help = "removes all entries by a user from the queue";
+        this.arguments = "<user>";
+        this.aliases = new String[]{"forcedelete", "modremove", "moddelete"};
+        this.beListening = false;
         this.bePlaying = true;
     }
 
     @Override
-    public void doCommand(CommandEvent event) {
-        if (event.getArgs().isEmpty()) {
+    public void doCommand(CommandEvent event)
+    {
+        if (event.getArgs().isEmpty())
+        {
             event.replyError("You need to mention a user!");
+            return;
         }
 
         AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
-        if (handler.getQueue().isEmpty()) {
+        if (handler.getQueue().isEmpty())
+        {
             event.replyError("There is nothing in the queue!");
             return;
         }
 
-        long target = -1;
-        String args = event.getArgs();
 
-        if (args.startsWith("<@") && args.endsWith(">")) {
-            try {
-                target = Long.parseLong(args.substring(2, args.length() - 1));
-            } catch (NumberFormatException ignored) {}
-        } else if (args.startsWith("<@!") && args.endsWith(">")) {
-            try {
-                target = Long.parseLong(args.substring(3, args.length() - 1));
-            } catch (NumberFormatException ignored) {}
-        } else {
-            try {
-                target = Long.parseLong(args);
-            } catch (NumberFormatException ignored) {}
-        }
-        if (target <= 0) {
-            event.replyError("You need to mention a user!");
+        User target;
+        List<Member> found = FinderUtil.findMembers(event.getArgs(), event.getGuild());
+
+        if(found.isEmpty())
+        {
+            event.replyError("Unable to find the user!");
             return;
         }
-
-        int count = handler.getQueue().removeAll(target);
-        if (count == 0)
-            event.replyWarning("This user doesn't have any songs in the queue!");
+        else if(found.size()>1)
+        {
+            event.replyWarning("Found multiple users!");
+            return;
+        }
         else
-            event.replySuccess("Successfully removed their " + count + " entries.");
+        {
+            target = found.get(0).getUser();
+        }
+
+
+        int count = handler.getQueue().removeAll(target.getIdLong());
+        if (count == 0)
+        {
+            event.replyWarning(target.getName() + " doesn't have any songs in the queue!");
+        }
+        else
+        {
+                event.replySuccess("Successfully removed `" + count + "` entries from **" + target.getName() + "**#" + target.getDiscriminator() + ".");
+        }
 
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -1,0 +1,63 @@
+package com.jagrosh.jmusicbot.commands.dj;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.audio.AudioHandler;
+import com.jagrosh.jmusicbot.commands.MusicCommand;
+
+
+public class ForceRemoveCmd extends MusicCommand {
+    public ForceRemoveCmd(Bot bot) {
+        super(bot);
+        this.name = "forceremove";
+        this.help = "removes all entries by the mentioned user from the queue";
+        this.arguments = "<@user|id>";
+        this.aliases = new String[]{"forcedelete"};
+        this.beListening = true;
+        this.bePlaying = true;
+    }
+
+    @Override
+    public void doCommand(CommandEvent event) {
+        if (event.getArgs().isEmpty()) {
+            event.replyError("You need to mention a user!");
+        }
+
+        AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
+        if (handler.getQueue().isEmpty()) {
+            event.replyError("There is nothing in the queue!");
+            return;
+        }
+
+        long target = -1;
+        String args = event.getArgs();
+
+        if (args.startsWith("<@") && args.endsWith(">")) {
+            try {
+                target = Long.parseLong(args.substring(2, args.length() - 1));
+            } catch (NumberFormatException ignored) {}
+        } else if (args.startsWith("<@!") && args.endsWith(">")) {
+            try {
+                target = Long.parseLong(args.substring(3, args.length() - 1));
+            } catch (NumberFormatException ignored) {}
+        } else {
+            try {
+                target = Long.parseLong(args);
+            } catch (NumberFormatException ignored) {
+                event.replyError("You need to mention a user!");
+                return;
+            }
+        }
+        if (target <= 0) {
+            event.replyError("You need to mention a user!");
+            return;
+        }
+
+        int count = handler.getQueue().removeAll(target);
+        if (count == 0)
+            event.replyWarning("This user doesn't have any songs in the queue!");
+        else
+            event.replySuccess("Successfully removed their " + count + " entries.");
+
+    }
+}


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds a `forceremove` command, which bulk deletes all entries made by a user. The command accepts mentions and id's.
### Purpose
As described in #237, DJ's may use it in case a user maliciously or accidentally adds many songs to the queue.

### Relevant Issue(s)
This PR closes #237
