### PR TITLE
Add copyright and author to ForceRemoveCmd.java

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
@@ -13,7 +28,10 @@ import net.dv8tion.jda.core.entities.User;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-
+/**
+ *
+ * @author Michaili K.
+ */
 public class ForceRemoveCmd extends DJCommand
 {
     public ForceRemoveCmd(Bot bot)


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance
  - [x] Other
### Description
[ForceRemoveCmd.java](https://github.com/jagrosh/MusicBot/blob/master/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java) misses the following comment at the top of the file:
```
/*
 * Copyright 2019 John Grosh <john.a.grosh@gmail.com>.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```
The author is also missing in [ForceRemoveCmd.java](https://github.com/jagrosh/MusicBot/blob/master/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java). This pull request adds both to [ForceRemoveCmd.java](https://github.com/jagrosh/MusicBot/blob/master/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java).

### Purpose
See description

### Relevant Issue(s)
No relevant issues.
