### PR TITLE
Fix player being paused when it is paused, then the queue being cleared

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -166,6 +166,9 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
                 manager.getBot().getNowplayingHandler().onTrackUpdate(guildId, null, this);
                 if(!manager.getBot().getConfig().getStay())
                     manager.getBot().closeAudioConnection(guildId);
+                // unpause, in the case when the player was paused and the track has been skipped.
+                // this is to prevent the player being paused next time it's being used.
+                player.setPaused(false);
             }
         }
         else


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR unpauses the player to fix #75 when the queue is cleared. This prevents the player from staying paused next time it's being used.

### Purpose
A user may pause the player and clear the queue or skip all entries in the queue. The player is still paused and needs to be resumed next time anyone wants to use the player. 

### Relevant Issue(s)
This PR closes #75 