### PR TITLE
Fix bot staying in channel when loading track fails

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -182,6 +182,11 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
         manager.getBot().getNowplayingHandler().onTrackUpdate(guildId, track, this);
     }
 
+    public void onTrackLoadFailed()
+    {
+        if(audioPlayer.getPlayingTrack() == null)
+            onTrackEnd(audioPlayer, null, AudioTrackEndReason.LOAD_FAILED);
+    }
     
     // Formatting
     public Message getNowPlaying(JDA jda)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
@@ -79,6 +79,8 @@ public class PlaynextCmd extends DJCommand
             {
                 m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is longer than the allowed maximum: `"
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+FormatUtil.formatTime(bot.getConfig().getMaxSeconds()*1000)+"`")).queue();
+
+                ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
                 return;
             }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
@@ -114,6 +116,8 @@ public class PlaynextCmd extends DJCommand
                 m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" No results found for `"+event.getArgs()+"`.")).queue();
             else
                 bot.getPlayerManager().loadItemOrdered(event.getGuild(), "ytsearch:"+event.getArgs(), new ResultHandler(m,event,true));
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
 
         @Override
@@ -123,6 +127,8 @@ public class PlaynextCmd extends DJCommand
                 m.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
             else
                 m.editMessage(event.getClient().getError()+" Error loading track.").queue();
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -184,6 +184,8 @@ public class PlayCmd extends MusicCommand
                 {
                     m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" All entries in this playlist "+(playlist.getName()==null ? "" : "(**"+playlist.getName()
                             +"**) ")+"were longer than the allowed maximum (`"+bot.getConfig().getMaxTime()+"`)")).queue();
+
+                    ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
                 }
                 else
                 {
@@ -203,6 +205,8 @@ public class PlayCmd extends MusicCommand
                 m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" No results found for `"+event.getArgs()+"`.")).queue();
             else
                 bot.getPlayerManager().loadItemOrdered(event.getGuild(), "ytsearch:"+event.getArgs(), new ResultHandler(m,event,true));
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
 
         @Override
@@ -212,6 +216,8 @@ public class PlayCmd extends MusicCommand
                 m.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
             else
                 m.editMessage(event.getClient().getError()+" Error loading track.").queue();
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -116,6 +116,8 @@ public class PlayCmd extends MusicCommand
             {
                 m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is longer than the allowed maximum: `"
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+FormatUtil.formatTime(bot.getConfig().getMaxSeconds()*1000)+"`")).queue();
+                
+                ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
                 return;
             }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
@@ -89,6 +89,8 @@ public class SearchCmd extends MusicCommand
             {
                 m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is longer than the allowed maximum: `"
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+bot.getConfig().getMaxTime()+"`")).queue();
+
+                ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
                 return;
             }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
@@ -111,6 +113,8 @@ public class SearchCmd extends MusicCommand
                         {
                             event.replyWarning("This track (**"+track.getInfo().title+"**) is longer than the allowed maximum: `"
                                     +FormatUtil.formatTime(track.getDuration())+"` > `"+bot.getConfig().getMaxTime()+"`");
+
+                            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
                             return;
                         }
                         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
@@ -119,7 +123,7 @@ public class SearchCmd extends MusicCommand
                                 +"** (`"+FormatUtil.formatTime(track.getDuration())+"`) "+(pos==0 ? "to begin playing" 
                                     : " to the queue at position "+pos));
                     })
-                    .setCancel((msg) -> {})
+                    .setCancel((msg) -> ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed())
                     .setUsers(event.getAuthor())
                     ;
             for(int i=0; i<4 && i<playlist.getTracks().size(); i++)
@@ -134,6 +138,8 @@ public class SearchCmd extends MusicCommand
         public void noMatches() 
         {
             m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" No results found for `"+event.getArgs()+"`.")).queue();
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
 
         @Override
@@ -143,6 +149,8 @@ public class SearchCmd extends MusicCommand
                 m.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
             else
                 m.editMessage(event.getClient().getError()+" Error loading track.").queue();
+
+            ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).onTrackLoadFailed();
         }
     }
 }


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR fixes #129, where the bot stays in the voice channel when loading a track fails (i.e. the track hasn't been found).
I can imagine that many people dislike my fix, especially because it looks hacky.

### Purpose
See description

### Relevant Issue(s)
This PR closes #129
