### PR TITLE
Fix bot joining in AFK voice channels

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -68,7 +68,7 @@ public abstract class MusicCommand extends Command
             if(current==null)
                 current = settings.getVoiceChannel(event.getGuild());
             GuildVoiceState userState = event.getMember().getVoiceState();
-            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
+            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)) || userState.getGuild().getAfkChannel().equals(userState.getChannel()))
             {
                 event.replyError("You must be listening in "+(current==null ? "a voice channel" : "**"+current.getName()+"**")+" to use that!");
                 return;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -68,11 +68,18 @@ public abstract class MusicCommand extends Command
             if(current==null)
                 current = settings.getVoiceChannel(event.getGuild());
             GuildVoiceState userState = event.getMember().getVoiceState();
-            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)) || userState.getGuild().getAfkChannel().equals(userState.getChannel()))
+            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
             {
                 event.replyError("You must be listening in "+(current==null ? "a voice channel" : "**"+current.getName()+"**")+" to use that!");
                 return;
             }
+
+            if(userState.getGuild().getAfkChannel().equals(userState.getChannel()))
+            {
+                event.replyError("You cannot use that command in an AFK channel!");
+                return;
+            }
+
             if(!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel())
             {
                 try 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -74,8 +74,8 @@ public abstract class MusicCommand extends Command
                 return;
             }
 
-VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
-if(afkChannel != null && afkChannel.equals(userState.getChannel()))
+            VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
+            if(afkChannel != null && afkChannel.equals(userState.getChannel()))
             {
                 event.replyError("You cannot use that command in an AFK channel!");
                 return;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -74,7 +74,8 @@ public abstract class MusicCommand extends Command
                 return;
             }
 
-            if(userState.getGuild().getAfkChannel().equals(userState.getChannel()))
+VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
+if(afkChannel != null && afkChannel.equals(userState.getChannel()))
             {
                 event.replyError("You cannot use that command in an AFK channel!");
                 return;


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Since Discord automatically mutes users in AFK channels, bots shouldn't
play music inside AFK channels. This PR also fixes #147.
**This may be a controversial PR, since it takes away the freedom of using music commands in AFK channels.**

### Purpose
This prevents users from playing music in AFK channels, where all users are guild-muted.

### Relevant Issue(s)
This PR closes #147.
