### PR TITLE
Add wrapping of page ends in queue command

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -57,6 +57,7 @@ public class QueueCmd extends MusicCommand
                 .waitOnSinglePage(false)
                 .useNumberedItems(true)
                 .showPageNumbers(true)
+                .wrapPageEnds(true)
                 .setEventWaiter(bot.getWaiter())
                 .setTimeout(1, TimeUnit.MINUTES);
     }


### PR DESCRIPTION
(Yes, I know, this is my fifth pull request as of today. I'll stop for now.)

### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This feature wraps both page ends, meaning that users can jump from the first page to the last page, using the previous page reaction, while using the next page button on the last page brings you to the first page.

### Purpose
This feature enhances user navigation, especially in large queues.

### Relevant Issue(s)
This PR closes #233.
