### PR TITLE
Fix nowplaying being updated even when NPImages is true.

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
@@ -47,7 +47,8 @@ public class NowplayingHandler
     
     public void init()
     {
-        bot.getThreadpool().scheduleWithFixedDelay(() -> updateAll(), 0, 5, TimeUnit.SECONDS);
+        if(!bot.getConfig().useNPImages())
+            bot.getThreadpool().scheduleWithFixedDelay(() -> updateAll(), 0, 5, TimeUnit.SECONDS);
     }
     
     public void setLastNPMessage(Message m)


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR fixes a bug, where the embed in the nowplaying command is being updated, even if npimages has been set to true, while the documentation of the setting says otherwise (that it won't update the nowplaying embed).

### Purpose
(Empty)

### Relevant Issue(s)
This PR has no relevant issues.
