### PR TITLE
Add Aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,31 @@
 *.json
 *.txt
 nb*.xml
+/bin/
+*target*
+*.jar
+*.war
+*.ear
+*.class
+
+# eclipse specific git ignore
+*.pydevproject
+.project
+.metadata
+bin/**
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.classpath
+.settings/
+.loadpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -40,7 +40,7 @@ public class ForceRemoveCmd extends DJCommand
         this.name = "forceremove";
         this.help = "removes all entries by a user from the queue";
         this.arguments = "<user>";
-        this.aliases = new String[]{"forcedelete", "modremove", "moddelete"};
+        this.aliases = new String[]{"frm", "forcedelete", "modremove", "moddelete"};
         this.beListening = false;
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
@@ -32,7 +32,7 @@ public class ForceskipCmd extends DJCommand
         super(bot);
         this.name = "forceskip";
         this.help = "skips the current song";
-        this.aliases = new String[]{"modskip"};
+        this.aliases = new String[]{"fs", "modskip"};
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -20,7 +20,7 @@ public class MoveTrackCmd extends DJCommand
         this.name = "movetrack";
         this.help = "move a track in the current queue to a different position";
         this.arguments = "<from> <to>";
-        this.aliases = new String[]{"move"};
+        this.aliases = new String[]{"mv", "move"};
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -51,6 +51,7 @@ public class PlayCmd extends MusicCommand
         super(bot);
         this.loadingEmoji = bot.getConfig().getLoading();
         this.name = "play";
+        this.aliases = new String[]{"p"};
         this.arguments = "<title|URL|subcommand>";
         this.help = "plays the provided song";
         this.beListening = true;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -47,7 +47,7 @@ public class QueueCmd extends MusicCommand
         this.name = "queue";
         this.help = "shows the current queue";
         this.arguments = "[pagenum]";
-        this.aliases = new String[]{"list"};
+        this.aliases = new String[]{"q", "list"};
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION,Permission.MESSAGE_EMBED_LINKS};
         builder = new Paginator.Builder()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
@@ -36,7 +36,7 @@ public class RemoveCmd extends MusicCommand
         this.name = "remove";
         this.help = "removes a song from the queue";
         this.arguments = "<position|ALL>";
-        this.aliases = new String[]{"delete"};
+        this.aliases = new String[]{"rm", "delete"};
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -32,7 +32,7 @@ public class SkipCmd extends MusicCommand
         super(bot);
         this.name = "skip";
         this.help = "votes to skip the current song";
-        this.aliases = new String[]{"voteskip"};
+        this.aliases = new String[]{"s", "voteskip"};
         this.beListening = true;
         this.bePlaying = true;
     }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [X] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Adds shortcut aliases to commonly used commands

### Purpose
Sometimes it is tiresome to always have to type !play for a command to work. Just like Rythm Bot, it might be nice to add a few shortcut aliases like !p for play, !s for skip, etc.

It's relatively easy to implement. You could even do it yourself instead of using this PR.

### Relevant Issue(s)
None
