### PR TITLE
Add configurable aliases for all commands

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -46,8 +46,9 @@ public class BotConfig
     private long owner, maxSeconds;
     private OnlineStatus status;
     private Game game;
+    private Config aliases;
 
-    private Config config;
+
     private boolean valid = false;
     
     public BotConfig(Prompt prompt)
@@ -73,7 +74,7 @@ public class BotConfig
             
             // load in the config file, plus the default values
             //Config config = ConfigFactory.parseFile(path.toFile()).withFallback(ConfigFactory.load());
-            config = ConfigFactory.load();
+            Config config = ConfigFactory.load();
             
             // set values
             token = config.getString("token");
@@ -95,6 +96,7 @@ public class BotConfig
             useEval = config.getBoolean("eval");
             maxSeconds = config.getLong("maxtime");
             playlistsFolder = config.getString("playlistsfolder");
+            aliases = config.getConfig("aliases");
             dbots = owner == 113156185389092864L;
             
             // we may need to write a new config file
@@ -304,9 +306,13 @@ public class BotConfig
 
     public String[] getAliases(String command)
     {
-        String aliases = config.getString("alias."+command);
-        if(aliases == null || aliases.length() <= 0)
-            return new String[]{};
-        return aliases.split(" ");
+        try
+        {
+            return aliases.getStringList(command).toArray(new String[0]);
+        }
+        catch(NullPointerException e)
+        {
+            return new String[0];
+        }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -310,7 +310,7 @@ public class BotConfig
         {
             return aliases.getStringList(command).toArray(new String[0]);
         }
-        catch(NullPointerException e)
+        catch(NullPointerException | ConfigException.Missing e)
         {
             return new String[0];
         }

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -46,7 +46,8 @@ public class BotConfig
     private long owner, maxSeconds;
     private OnlineStatus status;
     private Game game;
-    
+
+    private Config config;
     private boolean valid = false;
     
     public BotConfig(Prompt prompt)
@@ -72,7 +73,7 @@ public class BotConfig
             
             // load in the config file, plus the default values
             //Config config = ConfigFactory.parseFile(path.toFile()).withFallback(ConfigFactory.load());
-            Config config = ConfigFactory.load();
+            config = ConfigFactory.load();
             
             // set values
             token = config.getString("token");
@@ -299,5 +300,13 @@ public class BotConfig
         if(maxSeconds<=0)
             return false;
         return Math.round(track.getDuration()/1000.0) > maxSeconds;
+    }
+
+    public String[] getAliases(String command)
+    {
+        String aliases = config.getString("alias."+command);
+        if(aliases == null || aliases.length() <= 0)
+            return new String[]{};
+        return aliases.split(" ");
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -46,7 +46,6 @@ public class JMusicBot
     public final static Permission[] RECOMMENDED_PERMS = new Permission[]{Permission.MESSAGE_READ, Permission.MESSAGE_WRITE, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
                                 Permission.MANAGE_CHANNEL, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
-    public static BotConfig config;
     /**
      * @param args the command line arguments
      */
@@ -72,7 +71,7 @@ public class JMusicBot
         String version = OtherUtil.checkVersion(prompt);
         
         // load config
-        config = new BotConfig(prompt);
+        BotConfig config = new BotConfig(prompt);
         config.load();
         if(!config.isValid())
             return;
@@ -100,7 +99,7 @@ public class JMusicBot
                 .setGuildSettingsManager(settings)
                 .addCommands(aboutCommand,
                         new PingCommand(),
-                        new SettingsCmd(),
+                        new SettingsCmd(bot),
                         
                         new LyricsCmd(bot),
                         new NowplayingCmd(bot),
@@ -123,17 +122,17 @@ public class JMusicBot
                         new StopCmd(bot),
                         new VolumeCmd(bot),
                         
-                        new SetdjCmd(),
-                        new SettcCmd(),
-                        new SetvcCmd(),
+                        new SetdjCmd(bot),
+                        new SettcCmd(bot),
+                        new SetvcCmd(bot),
                         
                         new AutoplaylistCmd(bot),
                         new DebugCmd(bot),
                         new PlaylistCmd(bot),
-                        new SetavatarCmd(),
-                        new SetgameCmd(),
-                        new SetnameCmd(),
-                        new SetstatusCmd(),
+                        new SetavatarCmd(bot),
+                        new SetgameCmd(bot),
+                        new SetnameCmd(bot),
+                        new SetstatusCmd(bot),
                         new ShutdownCmd(bot)
                 );
         if(config.useEval())

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -46,6 +46,7 @@ public class JMusicBot
     public final static Permission[] RECOMMENDED_PERMS = new Permission[]{Permission.MESSAGE_READ, Permission.MESSAGE_WRITE, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
                                 Permission.MANAGE_CHANNEL, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
+    public static BotConfig config;
     /**
      * @param args the command line arguments
      */
@@ -71,7 +72,7 @@ public class JMusicBot
         String version = OtherUtil.checkVersion(prompt);
         
         // load config
-        BotConfig config = new BotConfig(prompt);
+        config = new BotConfig(prompt);
         config.load();
         if(!config.isValid())
             return;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -18,7 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -30,12 +30,12 @@ import net.dv8tion.jda.core.entities.Role;
  */
 public class SetdjCmd extends AdminCommand
 {
-    public SetdjCmd()
+    public SetdjCmd(Bot bot)
     {
         this.name = "setdj";
         this.help = "sets the DJ role for certain music commands";
         this.arguments = "<rolename|NONE>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -34,6 +35,7 @@ public class SetdjCmd extends AdminCommand
         this.name = "setdj";
         this.help = "sets the DJ role for certain music commands";
         this.arguments = "<rolename|NONE>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -18,7 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -30,12 +30,12 @@ import net.dv8tion.jda.core.entities.TextChannel;
  */
 public class SettcCmd extends AdminCommand 
 {
-    public SettcCmd()
+    public SettcCmd(Bot bot)
     {
         this.name = "settc";
         this.help = "sets the text channel for music commands";
         this.arguments = "<channel|NONE>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -34,6 +35,7 @@ public class SettcCmd extends AdminCommand
         this.name = "settc";
         this.help = "sets the text channel for music commands";
         this.arguments = "<channel|NONE>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -34,6 +35,7 @@ public class SetvcCmd extends AdminCommand
         this.name = "setvc";
         this.help = "sets the voice channel for playing music";
         this.arguments = "<channel|NONE>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -18,7 +18,7 @@ package com.jagrosh.jmusicbot.commands.admin;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
@@ -30,12 +30,12 @@ import net.dv8tion.jda.core.entities.VoiceChannel;
  */
 public class SetvcCmd extends AdminCommand 
 {
-    public SetvcCmd()
+    public SetvcCmd(Bot bot)
     {
         this.name = "setvc";
         this.help = "sets the voice channel for playing music";
         this.arguments = "<channel|NONE>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -19,7 +19,6 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
 import com.jagrosh.jdautilities.menu.OrderedMenu;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import net.dv8tion.jda.core.Permission;
@@ -41,7 +40,7 @@ public class ForceRemoveCmd extends DJCommand
         this.name = "forceremove";
         this.help = "removes all entries by a user from the queue";
         this.arguments = "<user>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = false;
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -19,6 +19,7 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.utils.FinderUtil;
 import com.jagrosh.jdautilities.menu.OrderedMenu;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import net.dv8tion.jda.core.Permission;
@@ -40,7 +41,7 @@ public class ForceRemoveCmd extends DJCommand
         this.name = "forceremove";
         this.help = "removes all entries by a user from the queue";
         this.arguments = "<user>";
-        this.aliases = new String[]{"forcedelete", "modremove", "moddelete"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = false;
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import net.dv8tion.jda.core.entities.User;
@@ -33,7 +32,7 @@ public class ForceskipCmd extends DJCommand
         super(bot);
         this.name = "forceskip";
         this.help = "skips the current song";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import net.dv8tion.jda.core.entities.User;
@@ -32,7 +33,7 @@ public class ForceskipCmd extends DJCommand
         super(bot);
         this.name = "forceskip";
         this.help = "skips the current song";
-        this.aliases = new String[]{"modskip"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -3,6 +3,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
@@ -20,7 +21,7 @@ public class MoveTrackCmd extends DJCommand
         this.name = "movetrack";
         this.help = "move a track in the current queue to a different position";
         this.arguments = "<from> <to>";
-        this.aliases = new String[]{"move"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -3,7 +3,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
@@ -21,7 +20,7 @@ public class MoveTrackCmd extends DJCommand
         this.name = "movetrack";
         this.help = "move a track in the current queue to a different position";
         this.arguments = "<from> <to>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PauseCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PauseCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -32,7 +31,7 @@ public class PauseCmd extends DJCommand
         super(bot);
         this.name = "pause";
         this.help = "pauses the current song";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PauseCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PauseCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -31,6 +32,7 @@ public class PauseCmd extends DJCommand
         super(bot);
         this.name = "pause";
         this.help = "pauses the current song";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
@@ -43,7 +42,7 @@ public class PlaynextCmd extends DJCommand
         this.name = "playnext";
         this.arguments = "<title|URL>";
         this.help = "plays a single song next";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
         this.bePlaying = false;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
@@ -42,6 +43,7 @@ public class PlaynextCmd extends DJCommand
         this.name = "playnext";
         this.arguments = "<title|URL>";
         this.help = "plays a single song next";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = true;
         this.bePlaying = false;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 
@@ -32,6 +33,7 @@ public class RepeatCmd extends DJCommand
         this.name = "repeat";
         this.help = "re-adds music to the queue when finished";
         this.arguments = "[on|off]";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = true;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 
@@ -33,7 +32,7 @@ public class RepeatCmd extends DJCommand
         this.name = "repeat";
         this.help = "re-adds music to the queue when finished";
         this.arguments = "[on|off]";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -33,7 +32,7 @@ public class SkiptoCmd extends DJCommand
         this.name = "skipto";
         this.help = "skips to the specified song";
         this.arguments = "<position>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -32,7 +33,7 @@ public class SkiptoCmd extends DJCommand
         this.name = "skipto";
         this.help = "skips to the specified song";
         this.arguments = "<position>";
-        this.aliases = new String[]{"jumpto"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = true;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -32,7 +31,7 @@ public class StopCmd extends DJCommand
         super(bot);
         this.name = "stop";
         this.help = "stops the current song and clears the queue";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = false;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 
@@ -31,6 +32,7 @@ public class StopCmd extends DJCommand
         super(bot);
         this.name = "stop";
         this.help = "stops the current song and clears the queue";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = false;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
@@ -33,7 +32,7 @@ public class VolumeCmd extends DJCommand
     {
         super(bot);
         this.name = "volume";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.help = "sets or shows volume";
         this.arguments = "[0-150]";
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.dj;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
@@ -32,7 +33,7 @@ public class VolumeCmd extends DJCommand
     {
         super(bot);
         this.name = "volume";
-        this.aliases = new String[]{"vol"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.help = "sets or shows volume";
         this.arguments = "[0-150]";
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.general;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.settings.Settings;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -36,7 +37,7 @@ public class SettingsCmd extends Command
     {
         this.name = "settings";
         this.help = "shows the bots settings";
-        this.aliases = new String[]{"status"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = true;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -17,7 +17,7 @@ package com.jagrosh.jmusicbot.commands.general;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.settings.Settings;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -33,11 +33,11 @@ public class SettingsCmd extends Command
 {
     private final static String EMOJI = "\uD83C\uDFA7"; // 🎧
     
-    public SettingsCmd()
+    public SettingsCmd(Bot bot)
     {
         this.name = "settings";
         this.help = "shows the bots settings";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
@@ -19,6 +19,7 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jlyrics.Lyrics;
 import com.jagrosh.jlyrics.LyricsClient;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import java.util.concurrent.ExecutionException;
@@ -39,6 +40,7 @@ public class LyricsCmd extends MusicCommand
         this.name = "lyrics";
         this.arguments = "[song name]";
         this.help = "shows the lyrics to the currently-playing song";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
@@ -19,7 +19,6 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jlyrics.Lyrics;
 import com.jagrosh.jlyrics.LyricsClient;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import java.util.concurrent.ExecutionException;
@@ -40,7 +39,7 @@ public class LyricsCmd extends MusicCommand
         this.name = "lyrics";
         this.arguments = "[song name]";
         this.help = "shows the lyrics to the currently-playing song";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.core.Permission;
@@ -33,7 +34,7 @@ public class NowplayingCmd extends MusicCommand
         super(bot);
         this.name = "nowplaying";
         this.help = "shows the song that is currently playing";
-        this.aliases = new String[]{"np","current"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.core.Permission;
@@ -34,7 +33,7 @@ public class NowplayingCmd extends MusicCommand
         super(bot);
         this.name = "nowplaying";
         this.help = "shows the song that is currently playing";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -15,7 +15,6 @@
  */
 package com.jagrosh.jmusicbot.commands.music;
 
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
@@ -54,7 +53,7 @@ public class PlayCmd extends MusicCommand
         this.name = "play";
         this.arguments = "<title|URL|subcommand>";
         this.help = "plays the provided song";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
         this.bePlaying = false;
         this.children = new Command[]{new PlaylistCmd(bot)};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -15,6 +15,7 @@
  */
 package com.jagrosh.jmusicbot.commands.music;
 
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
@@ -53,6 +54,7 @@ public class PlayCmd extends MusicCommand
         this.name = "play";
         this.arguments = "<title|URL|subcommand>";
         this.help = "plays the provided song";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = true;
         this.bePlaying = false;
         this.children = new Command[]{new PlaylistCmd(bot)};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -18,7 +18,6 @@ package com.jagrosh.jmusicbot.commands.music;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 
 /**
@@ -32,7 +31,7 @@ public class PlaylistsCmd extends MusicCommand
         super(bot);
         this.name = "playlists";
         this.help = "shows the available playlists";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
         this.beListening = false;
         this.beListening = false;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.music;
 import java.util.List;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 
 /**
@@ -31,7 +32,7 @@ public class PlaylistsCmd extends MusicCommand
         super(bot);
         this.name = "playlists";
         this.help = "shows the available playlists";
-        this.aliases = new String[]{"pls"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = true;
         this.beListening = false;
         this.beListening = false;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -47,7 +47,7 @@ public class QueueCmd extends MusicCommand
         this.name = "queue";
         this.help = "shows the current queue";
         this.arguments = "[pagenum]";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION,Permission.MESSAGE_EMBED_LINKS};
         builder = new Paginator.Builder()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -47,7 +47,7 @@ public class QueueCmd extends MusicCommand
         this.name = "queue";
         this.help = "shows the current queue";
         this.arguments = "[pagenum]";
-        this.aliases = new String[]{"list"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION,Permission.MESSAGE_EMBED_LINKS};
         builder = new Paginator.Builder()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
@@ -37,7 +36,7 @@ public class RemoveCmd extends MusicCommand
         this.name = "remove";
         this.help = "removes a song from the queue";
         this.arguments = "<position|ALL>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
@@ -36,7 +37,7 @@ public class RemoveCmd extends MusicCommand
         this.name = "remove";
         this.help = "removes a song from the queue";
         this.arguments = "<position|ALL>";
-        this.aliases = new String[]{"delete"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
@@ -16,6 +16,7 @@
 package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 
 /**
  *
@@ -29,6 +30,6 @@ public class SCSearchCmd extends SearchCmd
         this.searchPrefix = "scsearch:";
         this.name = "scsearch";
         this.help = "searches Soundcloud for a provided query";
-        this.aliases = new String[]{};
+        this.aliases = JMusicBot.config.getAliases(this.name);
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
@@ -16,7 +16,6 @@
 package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 
 /**
  *

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
@@ -30,6 +30,6 @@ public class SCSearchCmd extends SearchCmd
         this.searchPrefix = "scsearch:";
         this.name = "scsearch";
         this.help = "searches Soundcloud for a provided query";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
@@ -15,7 +15,6 @@
  */
 package com.jagrosh.jmusicbot.commands.music;
 
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
@@ -47,7 +46,7 @@ public class SearchCmd extends MusicCommand
         super(bot);
         this.searchingEmoji = bot.getConfig().getSearching();
         this.name = "search";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.arguments = "<query>";
         this.help = "searches Youtube for a provided query";
         this.beListening = true;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
@@ -15,6 +15,7 @@
  */
 package com.jagrosh.jmusicbot.commands.music;
 
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
@@ -46,7 +47,7 @@ public class SearchCmd extends MusicCommand
         super(bot);
         this.searchingEmoji = bot.getConfig().getSearching();
         this.name = "search";
-        this.aliases = new String[]{"ytsearch"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.arguments = "<query>";
         this.help = "searches Youtube for a provided query";
         this.beListening = true;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 
@@ -32,7 +31,7 @@ public class ShuffleCmd extends MusicCommand
         super(bot);
         this.name = "shuffle";
         this.help = "shuffles songs you have added";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 
@@ -31,6 +32,7 @@ public class ShuffleCmd extends MusicCommand
         super(bot);
         this.name = "shuffle";
         this.help = "shuffles songs you have added";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.core.entities.User;
@@ -32,7 +33,7 @@ public class SkipCmd extends MusicCommand
         super(bot);
         this.name = "skip";
         this.help = "votes to skip the current song";
-        this.aliases = new String[]{"voteskip"};
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.core.entities.User;
@@ -33,7 +32,7 @@ public class SkipCmd extends MusicCommand
         super(bot);
         this.name = "skip";
         this.help = "votes to skip the current song";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 
@@ -36,7 +35,7 @@ public class AutoplaylistCmd extends OwnerCommand
         this.name = "autoplaylist";
         this.arguments = "<name|NONE>";
         this.help = "sets the default playlist for the server";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
     }
 
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 
@@ -35,6 +36,7 @@ public class AutoplaylistCmd extends OwnerCommand
         this.name = "autoplaylist";
         this.arguments = "<name|NONE>";
         this.help = "sets the default playlist for the server";
+        this.aliases = JMusicBot.config.getAliases(this.name);
     }
 
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
@@ -18,7 +18,6 @@ package com.jagrosh.jmusicbot.commands.owner;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.JDAUtilitiesInfo;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
@@ -42,7 +41,7 @@ public class DebugCmd extends OwnerCommand
         this.bot = bot;
         this.name = "debug";
         this.help = "shows debug info";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.JDAUtilitiesInfo;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
@@ -41,6 +42,7 @@ public class DebugCmd extends OwnerCommand
         this.bot = bot;
         this.name = "debug";
         this.help = "shows debug info";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
@@ -19,6 +19,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 
 /**
@@ -34,6 +35,7 @@ public class EvalCmd extends OwnerCommand
         this.bot = bot;
         this.name = "eval";
         this.help = "evaluates nashorn code";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
@@ -19,7 +19,6 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 
 /**
@@ -35,7 +34,7 @@ public class EvalCmd extends OwnerCommand
         this.bot = bot;
         this.name = "eval";
         this.help = "evaluates nashorn code";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -20,9 +20,7 @@ import java.util.List;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
-import com.jagrosh.jmusicbot.commands.owner.AutoplaylistCmd;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
 
 /**
@@ -39,7 +37,7 @@ public class PlaylistCmd extends OwnerCommand
         this.name = "playlist";
         this.arguments = "<append|delete|make|setdefault>";
         this.help = "playlist management";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.children = new OwnerCommand[]{
             new ListCmd(),
             new AppendlistCmd(),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.commands.owner.AutoplaylistCmd;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
@@ -38,6 +39,7 @@ public class PlaylistCmd extends OwnerCommand
         this.name = "playlist";
         this.arguments = "<append|delete|make|setdefault>";
         this.help = "playlist management";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.children = new OwnerCommand[]{
             new ListCmd(),
             new AppendlistCmd(),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
@@ -18,7 +18,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 import java.io.IOException;
 import java.io.InputStream;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import net.dv8tion.jda.core.entities.Icon;
@@ -29,12 +29,12 @@ import net.dv8tion.jda.core.entities.Icon;
  */
 public class SetavatarCmd extends OwnerCommand 
 {
-    public SetavatarCmd()
+    public SetavatarCmd(Bot bot)
     {
         this.name = "setavatar";
         this.help = "sets the avatar of the bot";
         this.arguments = "<url>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
@@ -18,6 +18,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 import java.io.IOException;
 import java.io.InputStream;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import net.dv8tion.jda.core.entities.Icon;
@@ -33,6 +34,7 @@ public class SetavatarCmd extends OwnerCommand
         this.name = "setavatar";
         this.help = "sets the avatar of the bot";
         this.arguments = "<url>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
@@ -16,7 +16,7 @@
 package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.entities.Game;
 
@@ -26,12 +26,12 @@ import net.dv8tion.jda.core.entities.Game;
  */
 public class SetgameCmd extends OwnerCommand
 {
-    public SetgameCmd()
+    public SetgameCmd(Bot bot)
     {
         this.name = "setgame";
         this.help = "sets the game the bot is playing";
         this.arguments = "[action] [game]";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
         this.children = new OwnerCommand[]{
             new SetlistenCmd(),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
@@ -16,6 +16,7 @@
 package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.entities.Game;
 
@@ -30,6 +31,7 @@ public class SetgameCmd extends OwnerCommand
         this.name = "setgame";
         this.help = "sets the game the bot is playing";
         this.arguments = "[action] [game]";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
         this.children = new OwnerCommand[]{
             new SetlistenCmd(),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 
@@ -27,12 +26,12 @@ import net.dv8tion.jda.core.exceptions.RateLimitedException;
  */
 public class SetnameCmd extends OwnerCommand
 {
-    public SetnameCmd()
+    public SetnameCmd(Bot bot)
     {
         this.name = "setname";
         this.help = "sets the name of the bot";
         this.arguments = "<name>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 
@@ -31,6 +32,7 @@ public class SetnameCmd extends OwnerCommand
         this.name = "setname";
         this.help = "sets the name of the bot";
         this.arguments = "<name>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
@@ -16,7 +16,7 @@
 package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jmusicbot.JMusicBot;
+import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.OnlineStatus;
 
@@ -26,12 +26,12 @@ import net.dv8tion.jda.core.OnlineStatus;
  */
 public class SetstatusCmd extends OwnerCommand
 {
-    public SetstatusCmd()
+    public SetstatusCmd(Bot bot)
     {
         this.name = "setstatus";
         this.help = "sets the status the bot displays";
         this.arguments = "<status>";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
@@ -16,6 +16,7 @@
 package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 import net.dv8tion.jda.core.OnlineStatus;
 
@@ -30,6 +31,7 @@ public class SetstatusCmd extends OwnerCommand
         this.name = "setstatus";
         this.help = "sets the status the bot displays";
         this.arguments = "<status>";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/ShutdownCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/ShutdownCmd.java
@@ -17,7 +17,6 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 
 /**
@@ -33,7 +32,7 @@ public class ShutdownCmd extends OwnerCommand
         this.bot = bot;
         this.name = "shutdown";
         this.help = "safely shuts down";
-        this.aliases = JMusicBot.config.getAliases(this.name);
+        this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/ShutdownCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/ShutdownCmd.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.commands.owner;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
 
 /**
@@ -32,6 +33,7 @@ public class ShutdownCmd extends OwnerCommand
         this.bot = bot;
         this.name = "shutdown";
         this.help = "safely shuts down";
+        this.aliases = JMusicBot.config.getAliases(this.name);
         this.guildOnly = false;
     }
     

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -152,6 +152,7 @@ aliases {
   shuffle = []
   skip = [ voteskip ]
 
+
   // Admin commands
 
   setdj = []

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -124,64 +124,66 @@ lyrics.default = "A-Z Lyrics"
 
 
 // These settings allow you to configure custom aliases for all commands.
-// Multiple aliases may be given, separated by spaces.
+// Multiple aliases may be given, separated by commas.
 //
 // Example 1: Giving command "play" the alias "p":
-// alias.play = "p"
+// play = [ p ]
 //
 // Example 2: Giving command "search" the aliases "yts" and "find":
-// alias.search = "yts find"
+// search = [ yts, find ]
 
-// General commands
+aliases {
 
-alias.settings = "status"
+  // General commands
 
-
-// Music commands
-
-alias.lyrics = ""
-alias.nowplaying = "np current"
-alias.play = ""
-alias.playlists = "pls"
-alias.queue = "list"
-alias.remove = "delete"
-alias.scsearch = ""
-alias.search = "ytsearch"
-alias.shuffle = ""
-alias.skip = "voteskip"
-
-// Admin commands
-
-alias.setdj = ""
-alias.settc = ""
-alias.setvc = ""
+  settings = [ status ]
 
 
-// DJ Commands
+  // Music commands
 
-alias.forceremove = "forcedelete modremove moddelete"
-alias.forceskip = "modskip"
-alias.movetrack = "move"
-alias.pause = ""
-alias.playnext = ""
-alias.repeat = ""
-alias.skipto = "jumpto"
-alias.stop = ""
-alias.volume = "vol"
+  lyrics = []
+  nowplaying = [ np, current ]
+  play = []
+  playlists = [ pls ]
+  queue = [ list ]
+  remove = [ delete ]
+  scsearch = []
+  search = [ ytsearch ]
+  shuffle = []
+  skip = [ voteskip ]
+
+  // Admin commands
+
+  setdj = []
+  settc = []
+  setvc = []
 
 
-// Owner commands
+  // DJ Commands
 
-alias.autoplaylist = ""
-alias.debug = ""
-alias.eval = ""
-alias.playlist = ""
-alias.setavatar = ""
-alias.setgame = ""
-alias.setname = ""
-alias.setstatus = ""
-alias.shutdown = ""
+  forceremove = [ forcedelete, modremove, moddelete ]
+  forceskip = [ modskip ]
+  movetrack = [ move ]
+  pause = []
+  playnext = []
+  repeat = []
+  skipto = [ jumpto ]
+  stop = []
+  volume = [ vol ]
 
+
+  // Owner commands
+
+  autoplaylist = []
+  debug = []
+  eval = []
+  playlist = []
+  setavatar = []
+  setgame = []
+  setname = []
+  setstatus = []
+  shutdown = []
+}
 
 // If you set this to true, it will enable the eval command for the bot owner. This command
 // allows the bot owner to run arbitrary code from the bot's account.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -167,7 +167,7 @@ alias.playnext = ""
 alias.repeat = ""
 alias.skipto = "jumpto"
 alias.stop = ""
-alias.volume = "v"
+alias.volume = "vol"
 
 
 // Owner commands

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -129,8 +129,8 @@ lyrics.default = "A-Z Lyrics"
 // Example 1: Giving command "play" the alias "p":
 // alias.play = "p"
 //
-// Example 2: Giving command "search" the aliases "s" and "find":
-// alias.search = "s find"
+// Example 2: Giving command "search" the aliases "yts" and "find":
+// alias.search = "yts find"
 
 // General commands
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -123,6 +123,66 @@ updatealerts=true
 lyrics.default = "A-Z Lyrics"
 
 
+// These settings allow you to configure custom aliases for all commands.
+// Multiple aliases may be given, separated by spaces.
+//
+// Example 1: Giving command "play" the alias "p":
+// alias.play = "p"
+//
+// Example 2: Giving command "search" the aliases "s" and "find":
+// alias.search = "s find"
+
+// General commands
+
+alias.settings = "status"
+
+
+// Music commands
+
+alias.lyrics = ""
+alias.nowplaying = "np current"
+alias.play = ""
+alias.playlists = "pls"
+alias.queue = "list"
+alias.remove = "delete"
+alias.scsearch = ""
+alias.search = "ytsearch"
+alias.shuffle = ""
+alias.skip = "voteskip"
+
+// Admin commands
+
+alias.setdj = ""
+alias.settc = ""
+alias.setvc = ""
+
+
+// DJ Commands
+
+alias.forceremove = "forcedelete modremove moddelete"
+alias.forceskip = "modskip"
+alias.movetrack = "move"
+alias.pause = ""
+alias.playnext = ""
+alias.repeat = ""
+alias.skipto = "jumpto"
+alias.stop = ""
+alias.volume = "v"
+
+
+// Owner commands
+
+alias.autoplaylist = ""
+alias.debug = ""
+alias.eval = ""
+alias.playlist = ""
+alias.setavatar = ""
+alias.setgame = ""
+alias.setname = ""
+alias.setstatus = ""
+alias.shutdown = ""
+
+
 // If you set this to true, it will enable the eval command for the bot owner. This command
 // allows the bot owner to run arbitrary code from the bot's account.
 //


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR allows owners to define aliases for all commands in the config.txt file by giving `{command.name}` in the `aliases`-block the value of all aliases as a list of strings.
For example, if one wants to add the alias `s` to the `skip` command, then they should add the following inside the `aliases`-block in the config.txt:
`skip = [ s ]`

If one wants to add the aliases `yts` and `find` to the `search` command, then they should add the following inside the `aliases`-block in the config.txt:
`search = [ yts, find ]`

All currently existing aliases have been moved to `reference.conf`.



#### Current issues:
A vague error is being written to the console if one uses an alias that is already being used by another alias or command:
```
$ java -Dnogui=true -jar JMusicBot.jar
[INFO] [Startup]: Loaded config from MusicBot\config.txt
[ERROR] [JMusicBot]: Some aspect of the configuration is invalid: java.lang.IllegalArgumentException: Command added has a name or alias that has already been indexed: "v"!
Config Location: MusicBot\config.txt
$
```
In this case, the following conflict has happened (config.txt):
```
aliases {
  volume = [ v ]
  skip = [ v ]
}
```
`volume` and `skip` both have the aliases `v` defined and causes the MusicBot to crash when trying to start it.



### Purpose
Some owners may want to add one or two-character prefixes, such as `p` for `play`, `s` for `skip`, `fs` for `forceskip` and so on.

### Relevant Issue(s)
This PR is inspired by #307.