### PR TITLE
Add additional repeat modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /target/
 /Playlists/
 /test/
+/.idea
+*.iml
 *.json
 *.txt
 nb*.xml

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.audio;
 
 import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
+import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -154,9 +155,13 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) 
     {
         // if the track ended normally, and we're in repeat mode, re-add it to the queue
-        if(endReason==AudioTrackEndReason.FINISHED && manager.getBot().getSettingsManager().getSettings(guildId).getRepeatMode())
-        {
-            queue.add(new QueuedTrack(track.makeClone(), track.getUserData(Long.class)==null ? 0L : track.getUserData(Long.class)));
+        if(endReason==AudioTrackEndReason.FINISHED) {
+            RepeatMode repeatMode = manager.getBot().getSettingsManager().getSettings(guildId).getRepeatMode();
+            if (repeatMode == RepeatMode.all) {
+                queue.add(new QueuedTrack(track.makeClone(), track.getUserData(Long.class) == null ? 0L : track.getUserData(Long.class)));
+            } else if (repeatMode == RepeatMode.single) {
+                queue.addAt(0, new QueuedTrack(track.makeClone(), track.getUserData(Long.class) == null ? 0L : track.getUserData(Long.class)));
+            }
         }
         
         if(queue.isEmpty())

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/RepeatCmd.java
@@ -18,6 +18,8 @@ package com.jagrosh.jmusicbot.commands.dj;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.DJCommand;
+import com.jagrosh.jmusicbot.commands.music.QueueCmd;
+import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 
 /**
@@ -30,8 +32,8 @@ public class RepeatCmd extends DJCommand
     {
         super(bot);
         this.name = "repeat";
-        this.help = "re-adds music to the queue when finished";
-        this.arguments = "[on|off]";
+        this.help = "replays the current song or re-adds music to the queue when finished";
+        this.arguments = "[off|single|all]";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
     }
@@ -40,27 +42,32 @@ public class RepeatCmd extends DJCommand
     @Override
     protected void execute(CommandEvent event) 
     {
-        boolean value;
+        RepeatMode value;
         Settings settings = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().isEmpty())
         {
-            value = !settings.getRepeatMode();
+            event.reply(QueueCmd.REPEAT+" Current repeat setting is `"+settings.getRepeatMode()+"`.");
+            return;
         }
-        else if(event.getArgs().equalsIgnoreCase("true") || event.getArgs().equalsIgnoreCase("on"))
+        else if(event.getArgs().equalsIgnoreCase(RepeatMode.off.toString()))
         {
-            value = true;
+            value = RepeatMode.off;
         }
-        else if(event.getArgs().equalsIgnoreCase("false") || event.getArgs().equalsIgnoreCase("off"))
+        else if(event.getArgs().equalsIgnoreCase(RepeatMode.single.toString()))
         {
-            value = false;
+            value = RepeatMode.single;
+        }
+        else if(event.getArgs().equalsIgnoreCase(RepeatMode.all.toString()))
+        {
+            value = RepeatMode.all;
         }
         else
         {
-            event.replyError("Valid options are `on` or `off` (or leave empty to toggle)");
+            event.replyError("Valid options are `off`, `single`, or `all`.");
             return;
         }
         settings.setRepeatMode(value);
-        event.replySuccess("Repeat mode is now `"+(value ? "ON" : "OFF")+"`");
+        event.replySuccess("Repeat mode is now `"+value.toString()+"`.");
     }
 
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -59,7 +59,7 @@ public class SettingsCmd extends Command
                         + "\nVoice Channel: " + (vchan == null ? "Any" : "**" + vchan.getName() + "**")
                         + "\nDJ Role: " + (role == null ? "None" : "**" + role.getName() + "**")
                         + "\nCustom Prefix: " + (s.getPrefix() == null ? "None" : "`" + s.getPrefix() + "`")
-                        + "\nRepeat Mode: **" + (s.getRepeatMode() ? "On" : "Off") + "**"
+                        + "\nRepeat Mode: **" + (s.getRepeatMode().toString()) + "**"
                         + "\nDefault Playlist: " + (s.getDefaultPlaylist() == null ? "None" : "**" + s.getDefaultPlaylist() + "**")
                         )
                 .setFooter(event.getJDA().getGuilds().size() + " servers | "

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -30,21 +30,18 @@ import net.dv8tion.jda.core.entities.VoiceChannel;
  *
  * @author John Grosh <john.a.grosh@gmail.com>
  */
-public class SettingsCmd extends Command 
-{
+public class SettingsCmd extends Command {
     private final static String EMOJI = "\uD83C\uDFA7"; // 🎧
-    
-    public SettingsCmd(Bot bot)
-    {
+
+    public SettingsCmd(Bot bot) {
         this.name = "settings";
         this.help = "shows the bots settings";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
     }
-    
+
     @Override
-    protected void execute(CommandEvent event) 
-    {
+    protected void execute(CommandEvent event) {
         Settings s = event.getClient().getSettingsFor(event.getGuild());
         MessageBuilder builder = new MessageBuilder()
                 .append(EMOJI + " **")
@@ -59,13 +56,13 @@ public class SettingsCmd extends Command
                         + "\nVoice Channel: " + (vchan == null ? "Any" : "**" + vchan.getName() + "**")
                         + "\nDJ Role: " + (role == null ? "None" : "**" + role.getName() + "**")
                         + "\nCustom Prefix: " + (s.getPrefix() == null ? "None" : "`" + s.getPrefix() + "`")
-                        + "\nRepeat Mode: **" + (s.getRepeatMode().toString()) + "**"
+                        + "\nRepeat Mode: **" + s.getRepeatMode() + "**"
                         + "\nDefault Playlist: " + (s.getDefaultPlaylist() == null ? "None" : "**" + s.getDefaultPlaylist() + "**")
-                        )
+                )
                 .setFooter(event.getJDA().getGuilds().size() + " servers | "
                         + event.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inVoiceChannel()).count()
                         + " audio connections", null);
         event.getChannel().sendMessage(builder.setEmbed(ebuilder.build()).build()).queue();
     }
-    
+
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -24,6 +24,7 @@ import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
+import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -37,7 +38,7 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
  */
 public class QueueCmd extends MusicCommand 
 {
-    private final static String REPEAT = "\uD83D\uDD01"; // 🔁
+    public final static String REPEAT = "\uD83D\uDD01"; // 🔁
     
     private final Paginator.Builder builder;
     
@@ -104,7 +105,7 @@ public class QueueCmd extends MusicCommand
         builder.build().paginate(event.getChannel(), pagenum);
     }
     
-    private String getQueueTitle(AudioHandler ah, String success, int songslength, long total, boolean repeatmode)
+    private String getQueueTitle(AudioHandler ah, String success, int songslength, long total, RepeatMode repeatmode)
     {
         StringBuilder sb = new StringBuilder();
         if(ah.getPlayer().getPlayingTrack()!=null)
@@ -114,6 +115,6 @@ public class QueueCmd extends MusicCommand
         }
         return FormatUtil.filter(sb.append(success).append(" Current Queue | ").append(songslength)
                 .append(" entries | `").append(FormatUtil.formatTime(total)).append("` ")
-                .append(repeatmode ? "| " + REPEAT : "").toString());
+                .append(repeatmode != RepeatMode.off ? "| " + REPEAT : "").toString());
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/settings/RepeatMode.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/RepeatMode.java
@@ -1,0 +1,23 @@
+package com.jagrosh.jmusicbot.settings;
+
+public enum RepeatMode {
+    off, single, all;
+
+    static RepeatMode fromString(String string) {
+        if (string.equalsIgnoreCase(RepeatMode.single.toString()))
+            return RepeatMode.single;
+        if (string.equalsIgnoreCase(RepeatMode.all.toString()))
+            return RepeatMode.all;
+        return RepeatMode.off;
+    }
+
+    static RepeatMode fromObject(Object object) {
+        // Check against previous boolean setting and default to the same behavior as "true" if set
+        if (object instanceof Boolean && (Boolean) object)
+            return RepeatMode.all;
+        // New setting, uses String
+        if (object instanceof String)
+            return fromString((String) object);
+        return RepeatMode.off;
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/settings/RepeatMode.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/RepeatMode.java
@@ -1,7 +1,15 @@
 package com.jagrosh.jmusicbot.settings;
 
+/**
+ * Replacement of the previous repeat boolean setting.
+ * - `off`: Same as the previous setting of `false` and disables any repeating.
+ * - `single`: Repeats the currently-playing track, as requested by the card references below.
+ * - `all`: Same as the previous setting of `true` by repeating the entire current queue.
+ */
 public enum RepeatMode {
-    off, single, all;
+    off,
+    single,
+    all;
 
     static RepeatMode fromString(String string) {
         if (string.equalsIgnoreCase(RepeatMode.single.toString()))

--- a/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
@@ -35,10 +35,10 @@ public class Settings implements GuildSettingsProvider
     protected long roleId;
     private int volume;
     private String defaultPlaylist;
-    private boolean repeatMode;
+    private RepeatMode repeatMode;
     private String prefix;
     
-    public Settings(SettingsManager manager, String textId, String voiceId, String roleId, int volume, String defaultPlaylist, boolean repeatMode, String prefix)
+    public Settings(SettingsManager manager, String textId, String voiceId, String roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix)
     {
         this.manager = manager;
         try
@@ -71,7 +71,7 @@ public class Settings implements GuildSettingsProvider
         this.prefix = prefix;
     }
     
-    public Settings(SettingsManager manager, long textId, long voiceId, long roleId, int volume, String defaultPlaylist, boolean repeatMode, String prefix)
+    public Settings(SettingsManager manager, long textId, long voiceId, long roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix)
     {
         this.manager = manager;
         this.textId = textId;
@@ -109,7 +109,7 @@ public class Settings implements GuildSettingsProvider
         return defaultPlaylist;
     }
     
-    public boolean getRepeatMode()
+    public RepeatMode getRepeatMode()
     {
         return repeatMode;
     }
@@ -156,7 +156,7 @@ public class Settings implements GuildSettingsProvider
         this.manager.writeSettings();
     }
     
-    public void setRepeatMode(boolean mode)
+    public void setRepeatMode(RepeatMode mode)
     {
         this.repeatMode = mode;
         this.manager.writeSettings();

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -41,9 +41,6 @@ public class SettingsManager implements GuildSettingsManager
             JSONObject loadedSettings = new JSONObject(new String(Files.readAllBytes(OtherUtil.getPath("serversettings.json"))));
             loadedSettings.keySet().forEach((id) -> {
                 JSONObject o = loadedSettings.getJSONObject(id);
-                // Backwards-compatible with old boolean-based repeat mode
-                Object repeat = o.has("repeat") ? o.get("repeat") : null;
-
                 settings.put(Long.parseLong(id), new Settings(this,
                         o.has("text_channel_id") ? o.getString("text_channel_id")    : null,
                         o.has("voice_channel_id")? o.getString("voice_channel_id")   : null,


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [X] Boosts code quality or performance

### Description
Switches from the old repeat setting of `true` or `false` to modes of `off`, `single`, or `all`.

### Purpose
This PR remains backwards-compatible with the previous setting that used Booleans to track an on/off state and will overwrite them once a new setting is set.

The new modes are:
- `off`: Same as the previous setting of `false` and disables any repeating.
- `single`: Repeats the currently-playing track, as requested by the card references below.
- `all`: Same as the previous setting of `true` by repeating the entire current queue.

### Relevant Issue(s)
This PR resolves https://github.com/jagrosh/MusicBot/projects/1#card-13098453.
I do recognize that this feature request was still under _Suggested_ but wanted to tackle something simple first. Please let me know if you have any suggestions.