### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = ""

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Please see the [Setup Page](https://github.com/jagrosh/MusicBot/wiki/Setup) in t
 
 ## Editing
 This bot (and the source code here) might not be easy to edit for inexperienced programmers. The main purpose of having the source public is to show the capabilities of the libraries, to allow others to understand how the bot works, and to allow those knowledgeable about java, JDA, and Discord bot development to contribute. There are many requirements and dependencies required to edit and compile it, and there will not be support provided for people looking to make changes on their own. Instead, consider making a feature request (see the above section). If you choose to make edits, please do so in accordance with the Apache 2.0 License.
+
+[![Run on Repl.it](https://repl.it/badge/github/jagrosh/MusicBot)](https://repl.it/github/jagrosh/MusicBot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).

### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Replace this with a description of the pull request

### Purpose
Replace this with a description of the problem or use-case

### Relevant Issue(s)
This PR closes issue #...
