### PR TITLE
Replacing lavaplayer with a maintained working fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         </repository>
         <!-- Devos Lavaplayers fork is hosted on jitpack -->
         <repository>
-		    <id>jitpack.io</id>
-		    <url>https://jitpack.io</url>
-		</repository>
+	    <id>jitpack.io</id>
+	    <url>https://jitpack.io</url>
+	</repository>
         <!-- Jitpack End -->
     </repositories>
     

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,12 @@
             <name>bintray</name>
             <url>https://dl.bintray.com/sedmelluq/com.sedmelluq</url>
         </repository>
+        <!-- Devos Lavaplayers fork is hosted on jitpack -->
+        <repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+        <!-- Jitpack End -->
     </repositories>
     
     <dependencies>
@@ -25,11 +31,20 @@
             <artifactId>JDA</artifactId> 
             <version>3.8.3_464</version>
         </dependency>
+<!-- commenting out offical lavaplayer for convenience until it gets updated, while its replaced with an unoffical fork (also used by lavalink)
         <dependency>
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer</artifactId>
             <version>1.3.50</version>
         </dependency>
+-->
+        <!-- Devos fork -->
+        <dependency>
+            <groupId>com.github.Devoxin</groupId>
+            <artifactId>lavaplayer</artifactId>
+            <version>1.3.52</version>
+        </dependency>
+        <!-- Devos fork end -->
         <dependency>
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer-natives-extra</artifactId>


### PR DESCRIPTION
Kodehawa suggested me to use Devos LP fork, until sed updated LP, also used by Fred in Lavalink.

### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [x] Boosts code quality or performance (maybe)

### Description
Fixes several Lavaplayer bugs

### Purpose
Bug fixing

### Relevant Issue(s)
This PR closes issue #500, #493, maybe #442, maybe #364 
