### PR TITLE
fix "[ERROR] [LocalAudioTrackExecutor]: Error in playback"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>1.3.55</version>
+            <version>1.3.63</version>
         </dependency>
         <dependency>
             <groupId>com.sedmelluq</groupId>


### PR DESCRIPTION
change lavaplayer version from 1.3.55 to 1.3.63

This pull requestFixes a bug

### Purpose
There's a probleme in version 0.3.2 JMusicBot where's it won't load certain song from youtube, mostly "(Official Video)" song.

the upgrade in version for lavaplayer fix the problem
