### PR TITLE
Allow lyrics to be available anytime anywhere, fix typos

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -38,7 +38,6 @@ public abstract class MusicCommand extends Command
     public MusicCommand(Bot bot)
     {
         this.bot = bot;
-        this.guildOnly = true;
         this.category = new Category("Music");
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -42,58 +42,48 @@ public abstract class MusicCommand extends Command
     }
     
     @Override
-    protected void execute(CommandEvent event) 
+    protected void execute(CommandEvent event)
     {
-        Settings settings = event.getClient().getSettingsFor(event.getGuild());
-        TextChannel tchannel = settings.getTextChannel(event.getGuild());
-        if(tchannel!=null && !event.getTextChannel().equals(tchannel))
-        {
-            try 
-            {
-                event.getMessage().delete().queue();
-            } catch(PermissionException ignore){}
-            event.replyInDm(event.getClient().getError()+" You can only use that command in "+tchannel.getAsMention()+"!");
-            return;
-        }
-        bot.getPlayerManager().setUpHandler(event.getGuild()); // no point constantly checking for this later
-        if(bePlaying && !((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).isMusicPlaying(event.getJDA()))
-        {
-            event.reply(event.getClient().getError()+" There must be music playing to use that!");
-            return;
-        }
-        if(beListening)
-        {
-            VoiceChannel current = event.getGuild().getSelfMember().getVoiceState().getChannel();
-            if(current==null)
-                current = settings.getVoiceChannel(event.getGuild());
-            GuildVoiceState userState = event.getMember().getVoiceState();
-            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
-            {
-                event.replyError("You must be listening in "+(current==null ? "a voice channel" : "**"+current.getName()+"**")+" to use that!");
-                return;
-            }
-
-            VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
-            if(afkChannel != null && afkChannel.equals(userState.getChannel()))
-            {
-                event.replyError("You cannot use that command in an AFK channel!");
-                return;
-            }
-
-            if(!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel())
-            {
-                try 
-                {
-                    event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
+        if (event.getChannelType().isGuild()) {
+            Settings settings = event.getClient().getSettingsFor(event.getGuild());
+            TextChannel tchannel = settings.getTextChannel(event.getGuild());
+            if (tchannel != null && !event.getTextChannel().equals(tchannel)) {
+                try {
+                    event.getMessage().delete().queue();
+                } catch (PermissionException ignore) {
                 }
-                catch(PermissionException ex) 
-                {
-                    event.reply(event.getClient().getError()+" I am unable to connect to **"+userState.getChannel().getName()+"**!");
+                event.replyInDm(event.getClient().getError() + " You can only use that command in " + tchannel.getAsMention() + "!");
+                return;
+            }
+            bot.getPlayerManager().setUpHandler(event.getGuild()); // no point constantly checking for this later
+            if (bePlaying && !((AudioHandler) event.getGuild().getAudioManager().getSendingHandler()).isMusicPlaying(event.getJDA())) {
+                event.reply(event.getClient().getError() + " There must be music playing to use that!");
+                return;
+            }
+            if (beListening) {
+                VoiceChannel current = event.getGuild().getSelfMember().getVoiceState().getChannel();
+                if (current == null)
+                    current = settings.getVoiceChannel(event.getGuild());
+                GuildVoiceState userState = event.getMember().getVoiceState();
+                if (!userState.inVoiceChannel() || userState.isDeafened() || (current != null && !userState.getChannel().equals(current))) {
+                    event.replyError("You must be listening in " + (current == null ? "a voice channel" : "**" + current.getName() + "**") + " to use that!");
                     return;
                 }
+                VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
+                if (afkChannel != null && afkChannel.equals(userState.getChannel())) {
+                    event.replyError("You cannot use that command in an AFK channel!");
+                    return;
+                }
+                if (!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel()) {
+                    try {
+                        event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
+                    } catch (PermissionException ex) {
+                        event.reply(event.getClient().getError() + " I am unable to connect to **" + userState.getChannel().getName() + "**!");
+                        return;
+                    }
+                }
             }
         }
-        
         doCommand(event);
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -37,7 +37,7 @@ public class SettingsCmd extends Command
     public SettingsCmd(Bot bot)
     {
         this.name = "settings";
-        this.help = "shows the bots settings";
+        this.help = "shows the bot’s settings";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
@@ -39,13 +39,13 @@ public class LyricsCmd extends MusicCommand
         this.help = "shows the lyrics to the currently-playing song";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
-        this.bePlaying = true;
+        this.guildOnly = false;
+        this.bePlaying = false;
     }
 
     @Override
     public void doCommand(CommandEvent event)
     {
-        event.getChannel().sendTyping().queue();
         String title;
         if(event.getArgs().isEmpty())
             title = ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).getPlayer().getPlayingTrack().getInfo().title;
@@ -67,18 +67,18 @@ public class LyricsCmd extends MusicCommand
             {
                 event.replyWarning("Lyrics for `" + title + "` found but likely not correct: " + lyrics.getURL());
             }
-            else if(lyrics.getContent().length()>2000)
+            else if(lyrics.getContent().length()>2048)
             {
                 String content = lyrics.getContent().trim();
-                while(content.length() > 2000)
+                while(content.length() > 2048)
                 {
-                    int index = content.lastIndexOf("\n\n", 2000);
+                    int index = content.lastIndexOf("\n\n", 2048);
                     if(index == -1)
-                        index = content.lastIndexOf("\n", 2000);
+                        index = content.lastIndexOf("\n", 2048);
                     if(index == -1)
-                        index = content.lastIndexOf(" ", 2000);
+                        index = content.lastIndexOf(" ", 2048);
                     if(index == -1)
-                        index = 2000;
+                        index = 2048;
                     event.reply(eb.setDescription(content.substring(0, index).trim()).build());
                     content = content.substring(index).trim();
                     eb.setAuthor(null).setTitle(null, null);

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
@@ -35,6 +35,7 @@ public class NowplayingCmd extends MusicCommand
         this.help = "shows the song that is currently playing";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
+        this.guildOnly = true;
     }
 
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -54,6 +54,7 @@ public class PlayCmd extends MusicCommand
         this.arguments = "<title|URL|subcommand>";
         this.help = "plays the provided song";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = true;
         this.beListening = true;
         this.bePlaying = false;
         this.children = new Command[]{new PlaylistCmd(bot)};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -48,6 +48,7 @@ public class QueueCmd extends MusicCommand
         this.help = "shows the current queue";
         this.arguments = "[pagenum]";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = true;
         this.bePlaying = true;
         this.botPermissions = new Permission[]{Permission.MESSAGE_ADD_REACTION,Permission.MESSAGE_EMBED_LINKS};
         builder = new Paginator.Builder()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
@@ -37,6 +37,7 @@ public class RemoveCmd extends MusicCommand
         this.help = "removes a song from the queue";
         this.arguments = "<position|ALL>";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = true;
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SCSearchCmd.java
@@ -28,7 +28,8 @@ public class SCSearchCmd extends SearchCmd
         super(bot);
         this.searchPrefix = "scsearch:";
         this.name = "scsearch";
-        this.help = "searches Soundcloud for a provided query";
+        this.help = "searches SoundCloud for a provided query";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = true;
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
@@ -49,6 +49,7 @@ public class SearchCmd extends MusicCommand
         this.aliases = bot.getConfig().getAliases(this.name);
         this.arguments = "<query>";
         this.help = "searches Youtube for a provided query";
+        this.guildOnly = true;
         this.beListening = true;
         this.bePlaying = false;
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/ShuffleCmd.java
@@ -32,6 +32,7 @@ public class ShuffleCmd extends MusicCommand
         this.name = "shuffle";
         this.help = "shuffles songs you have added";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = true;
         this.beListening = true;
         this.bePlaying = true;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -34,6 +34,7 @@ public class SkipCmd extends MusicCommand
         this.help = "votes to skip the current song";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.beListening = true;
+        this.guildOnly = true;
         this.bePlaying = true;
     }
 


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
In the present code, lyrics are only available when something is playing in the guild. I modified placement of `guildOnly` property from the MusicCommands.java to the individual files in commands/music folder, and set `bePlaying` to false in LyricsCmd.java

In addition, I fixed some typos in the `help` command (such as "Soundcloud" to "SoundCloud", "bots settings" to "bot’s settings", etc)

### Purpose
Sometimes users want to look up lyrics while listening to the song elsewhere, so it's better to not limit the `lyrics` functionality.

### Relevant Issue(s)
None, just an improvement
