### PR TITLE
[FEATURE] Adding join for switching channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.json
 *.txt
 nb*.xml
+JMusicBot.iml
+.idea

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -120,6 +120,7 @@ public class JMusicBot
                         new SkiptoCmd(bot),
                         new StopCmd(bot),
                         new VolumeCmd(bot),
+                        new JoinCmd(bot),
                         
                         new PrefixCmd(bot),
                         new SetdjCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
@@ -30,7 +30,7 @@ public abstract class DJCommand extends MusicCommand
     public DJCommand(Bot bot)
     {
         super(bot);
-        this.category = new Category("DJ", event -> checkDJPermission(event));
+        this.category = new Category("DJ", DJCommand::checkDJPermission);
     }
     
     public static boolean checkDJPermission(CommandEvent event)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
@@ -1,0 +1,46 @@
+package com.jagrosh.jmusicbot.commands.dj;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.commands.DJCommand;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class JoinCmd extends DJCommand {
+
+    public JoinCmd(Bot bot)
+    {
+        super(bot);
+        this.name = "join";
+        this.help = "moves the bot to your channel";
+        this.aliases = bot.getConfig().getAliases(this.name);
+        this.bePlaying = true;
+    }
+
+    @Override
+    public void doCommand(CommandEvent event) {
+
+        AudioManager manager = event.getGuild().getAudioManager();
+        Member member = event.getMember();
+
+        GuildVoiceState state = member.getVoiceState();
+
+        if(state == null) {
+            event.reply(":x: Couldn't find a channel you are in! Please join a channel");
+            return;
+        }
+
+        VoiceChannel vc = member.getVoiceState().getChannel();
+
+        if(vc == null) {
+            event.reply(":x: You are not in a channel! Please join one");
+            return;
+        }
+
+        manager.openAudioConnection(vc);
+        event.reply("Joined " + vc.getName());
+
+    }
+}


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ X ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ X ] Boosts code quality or performance

### Description
Added JoinCmd to switch channels when music plays for djs. 
Also added intellij stuff to gitignore and shortened something in DJCommand

### Purpose
If you are a dj and want to switch channels and don't have move permissions you couldn't switch the music bots channel without disconnectiong which closes the queue. Now you can just switch chanels with join!

### Relevant Issue(s)
This PR closes a thing on the road map.
