### PR TITLE
Add basic Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!pom.xml
+!src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG JAVA_VERSION=11
+
+FROM maven:3.6-openjdk-$JAVA_VERSION as builder
+
+WORKDIR /tmp/workdir
+
+COPY pom.xml ./
+
+RUN mvn dependency:go-offline
+
+COPY src/ ./src/
+
+RUN mvn package
+
+
+ARG JAVA_VERSION
+
+FROM openjdk:$JAVA_VERSION-jre
+
+COPY --from=builder /tmp/workdir/target/JMusicBot-*-All.jar /JMusicBot.jar
+
+CMD ["java", "-Dnogui=true", "-jar", "/JMusicBot.jar"]


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds a very basic Dockerfile. Packaged it for myself, but someone else might also find it useful. 
It uses multi-stage builds, greatly decreasing the size of the final image. If you also want to provide docker image downloads, both docker-hub and quay.io has automatic builders so there isn't need to configure much.
I've decided to put the jar in the rootfs because I never really know of a better UNIXy place. Open to suggestions.
