### PR TITLE
Removed broken and unused repository and dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,6 @@
             <name>bintray</name>
             <url>https://jcenter.bintray.com</url>
         </repository>
-        <repository>
-            <id>bintray-sedmelluq-com.sedmelluq</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/sedmelluq/com.sedmelluq</url>
-        </repository>
     </repositories>
     
     <dependencies>
@@ -34,11 +29,6 @@
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer</artifactId>
             <version>1.3.75</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sedmelluq</groupId>
-            <artifactId>lavaplayer-natives-extra</artifactId>
-            <version>1.3.13</version>
         </dependency>
         <dependency>
             <groupId>com.jagrosh</groupId>


### PR DESCRIPTION
### This pull request...
  - [X] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This removes dl.bintray.com, which no longer exists. It also removes lavaplayer-natives-extra, since this is not in the repository from Lavaplayer, and it compiles and the bot works without, so it seems to be unused. 

### Purpose
With this PR, this project can be compiled with `mvn clean package`.