### PR TITLE
My go at a Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3
+
+RUN apk update \
+ && apk add sudo \
+ && apk add openjdk11-jre \
+ && addgroup -g 1000 --system musicbot \
+ && adduser -u 1000 --system --no-create-home musicbot --ingroup musicbot \
+ && mkdir /bot \
+ && ln -s /bot-data/serversettings.json /bot/serversettings.json
+
+COPY start.sh /script/
+
+ARG VERSION
+COPY JMusicBot-${VERSION}.jar /bot/JMusicBot.jar
+
+CMD /script/start.sh

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+config="config.txt"
+
+cd /bot
+
+printf 'playlistsfolder = "/bot-data/playlists"\n\n' > $config
+
+if [ -e "/bot-data/config.txt" ]; then
+    cat "/bot-data/config.txt" >> $config
+elif [ -e "/config/config/txt" ]; then
+    cat "/config/config/txt" >> $config
+fi
+
+printf '\n\n' >> $config
+
+for envvar in $(awk "END { for (envvar in ENVIRON) { print envvar; }}" < /dev/null)
+do
+  if [ ! "$envvar" = "${envvar#MB-}" ]; then
+    value="$(awk "END { printf ENVIRON[\"$envvar\"]; }" < /dev/null)"
+    printf "${envvar#MB-} = $value\n\n" >> $config
+  fi
+done
+
+if [ ! -d "/bot-data" ]; then
+    mkdir /bot-data
+fi
+
+chown -R musicbot:musicbot .
+chown -R musicbot:musicbot /bot-data
+
+sudo -u musicbot java -Dnogui=true -jar JMusicBot.jar


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

## Description
I realize I'm not the first one to submit a Docker PR, but I'd still like to post how I've set it up.

### Configuration
The configuration can be set in multiple ways with this image:
* Firstly, a `config.txt` file can be added in `/bot-data/` or `/config/` (through a volume mount or by extending from this image and adding the file to `/config/`). This file will be copied to the bot's directory.
* Secondly, config values can be set through environment variables. This allows one to change the settings without a *config.txt* file. It also means it's possible to e.g. get the bot token from a secret in Kubernetes. Any environment variable prefixed with `MB-` will be added to the configuration (without the prefix). So, for example, to set the token and owner, set the following environment variables:
    * `MB-token=abc123`
    * `MB-owner=12345`

### Volume mounts
The *serversettings.json* file and playlists folder are saved to the `/bot-data/` directory. **It's recommended to mount this folder to some persistent storage, or the data is gonna be lost when the container is deleted.** It's possible to override the playlists folder in the config, but not recommended to do so. A *config.txt* file can also be added to the `/bot-data/` folder in order to set the configuration. It's also possible to add the *config.txt* file to `/config/` instead, which would also require a mount.

### Building the image
Right now, the Dockerfile expects there to be a `JMusicBot-<version>.jar` file in the `docker` folder for it to build. The version needs to be set using the `VERSION` build argument. Of course, this can be changed as needed to make it more convenient to build the image. I haven't put too much thought into this, because I'm not very familiar with Java and how to build the bot.

Basic instructions to build the image (open for improvement):
* Copy the `JMusicBot-<version>.jar` file to the `docker` folder
* Run `docker build -t musicbot:latest --build-arg VERSION=0.3.5 .` (change version as needed)
* To start, run: `docker run -e MB-token=abc123 -e MB-owner=12345 musicbot` (set the token and owner correctly)

The start example doesn't include a volume mount for `/bot-data/`, it's probably best to add that.

### Kubernetes deployment example
<details>
<summary>An example of a Kubernetes deployment I used to run the bot</summary>

Note that the image name depends on where the image is hosted and the volume mount depends on the Kubernetes hosting situation.

```YAML
apiVersion: apps/v1
kind: Deployment
metadata:
  name: musicbot
  namespace: musicbot
  labels:
    app: musicbot
spec:
  replicas: 1
  selector:
    matchLabels:
      app: musicbot
  template:
    metadata:
      labels:
        app: musicbot
    spec:
      containers:
      - name: musicbot
        image: musicbot:latest
        env:
        - name: MB-token
          value: abc123
        - name: MB-owner
          value: '12345'
        - name: MB-game
          value: '"Listening to music"'
        - name: MB-alonetimeuntilstop
          value: '60'
        volumeMounts:
          - name: musicbot-data
            mountPath: /bot-data
        resources:
          requests:
            memory: 64Mi
            cpu: 125m
          limits:
            memory: 512Mi
            cpu: 500m
      volumes:
      - name: musicbot-data
        [...]
```
</details>