### PR TITLE
Fix Windows path loading bug

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -67,7 +67,7 @@ public class BotConfig
             if(path.toFile().exists())
             {
                 if(System.getProperty("config.file") == null)
-                    System.setProperty("config.file", System.getProperty("config", "config.txt"));
+                    System.setProperty("config.file", System.getProperty("config", path.toAbsolutePath().toString()));
                 ConfigFactory.invalidateCaches();
             }
             

--- a/src/main/java/com/jagrosh/jmusicbot/playlist/PlaylistLoader.java
+++ b/src/main/java/com/jagrosh/jmusicbot/playlist/PlaylistLoader.java
@@ -46,7 +46,7 @@ public class PlaylistLoader
     {
         if(folderExists())
         {
-            File folder = new File(config.getPlaylistsFolder());
+            File folder = new File(OtherUtil.getPath(config.getPlaylistsFolder()).toString());
             return Arrays.asList(folder.listFiles((pathname) -> pathname.getName().endsWith(".txt")))
                     .stream().map(f -> f.getName().substring(0,f.getName().length()-4)).collect(Collectors.toList());
         }

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -52,17 +52,17 @@ public class OtherUtil
      */
     public static Path getPath(String path)
     {
+        Path result = Paths.get(path);
         // special logic to prevent trying to access system32
-        if(path.toLowerCase().startsWith(WINDOWS_INVALID_PATH))
+        if(result.toAbsolutePath().toString().toLowerCase().startsWith(WINDOWS_INVALID_PATH))
         {
-            String filename = path.substring(WINDOWS_INVALID_PATH.length());
             try
             {
-                path = new File(JMusicBot.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getPath() + File.separator + filename;
+                result = Paths.get(new File(JMusicBot.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getPath() + File.separator + path);
             }
             catch(URISyntaxException ex) {}
         }
-        return Paths.get(path);
+        return result;
     }
     
     /**


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This pull request fixes a Windows bug, where starting the MusicBot using `right click -> Open with...` would result in the bot attempting to read the config file in `C:\WINDOWS\system32`.

### Purpose
This fixes the MusicBot generally not starting for any Windows users using that method to start the MusicBot

### Relevant Issue(s)
closes #824, addresses #818 
