### PR TITLE
Add "clear" alias to stop command

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -169,7 +169,7 @@ aliases {
   playnext = []
   repeat = []
   skipto = [ jumpto ]
-  stop = []
+  stop = [ clear ]
   volume = [ vol ]
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -169,7 +169,7 @@ aliases {
   playnext = []
   repeat = []
   skipto = [ jumpto ]
-  stop = [ clear ]
+  stop = [ leave ]
   volume = [ vol ]
 }
 


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Adds a new alias for the `stop` command, "clear".

### Purpose
Some people seem to be unaware of `stop`'s existence, so it is perhaps a good idea to add "clear" as a default alias for the stop command.

### Relevant Issue(s)
See also #845 and #846
