### PR TITLE
Add "Known issues" section to Troubleshooting

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -9,6 +9,10 @@ permalink: /troubleshooting
 1. TOC
 {:toc}
 
+## Known issues
+### ⚠ SoundCloud URLs result in a "Error loading track." message!
+This is a known issue when attempting to load music from SoundCloud. It is tracked [here](https://github.com/jagrosh/MusicBot/issues/833) and will soon be fixed.
+
 ## Problems starting the bot
 ### ⚠ The .jar file is opening in WinRAR or is acting like a zipped file!
 * **Check your Java version** - You might not have Java installed

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -10,8 +10,7 @@ permalink: /troubleshooting
 {:toc}
 
 ## Known issues
-### ⚠ SoundCloud URLs result in a "Error loading track." message!
-This is a known issue when attempting to load music from SoundCloud. It is tracked [here](https://github.com/jagrosh/MusicBot/issues/833) and will soon be fixed.
+There may be temporary bugs or issues with MusicBot. Such as tracks not loading from specific sources, like YouTube or SoundCloud. See the [Issues](https://github.com/jagrosh/MusicBot/issues) page and check if your issue is known.
 
 ## Problems starting the bot
 ### ⚠ The .jar file is opening in WinRAR or is acting like a zipped file!


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds a "Known issues" section to the Wiki, which addresses known and on-going problems, like loading from SoundCloud (as of writing).

### Purpose
Users may be more likely referring to the Troubleshooting page, and see that their problem is known & being fixed, instead of opening duplicate issues or asking in the support server.

### Relevant Issue(s)
None necessarily.
