### PR TITLE
Allow usage of LyricsCmd without playing music

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/LyricsCmd.java
@@ -36,21 +36,29 @@ public class LyricsCmd extends MusicCommand
         super(bot);
         this.name = "lyrics";
         this.arguments = "[song name]";
-        this.help = "shows the lyrics to the currently-playing song";
+        this.help = "shows the lyrics of a song";
         this.aliases = bot.getConfig().getAliases(this.name);
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS};
-        this.bePlaying = true;
     }
 
     @Override
     public void doCommand(CommandEvent event)
     {
-        event.getChannel().sendTyping().queue();
         String title;
         if(event.getArgs().isEmpty())
-            title = ((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).getPlayer().getPlayingTrack().getInfo().title;
+        {
+            AudioHandler sendingHandler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
+            if (sendingHandler.isMusicPlaying(event.getJDA()))
+                title = sendingHandler.getPlayer().getPlayingTrack().getInfo().title;
+            else
+            {
+                event.replyError("There must be music playing to use that!");
+                return;
+            }
+        }
         else
             title = event.getArgs();
+        event.getChannel().sendTyping().queue();
         client.getLyrics(title).thenAccept(lyrics -> 
         {
             if(lyrics == null)


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Allows using the `lyrics` command without music playing.

### Purpose
Ability to get the lyrics of a song by using `lyrics [song name]`.

### Relevant Issue(s)
None
