### PR TITLE
Add admin command for enabling and disabling fair queuing

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -125,6 +125,7 @@ public class JMusicBot
                         new SkipratioCmd(bot),
                         new SettcCmd(bot),
                         new SetvcCmd(bot),
+                        new FairqueueCmd(bot),
                         
                         new AutoplaylistCmd(bot),
                         new DebugCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -85,7 +85,17 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
             return -1;
         }
         else
-            return queue.add(qtrack);
+        {
+            Settings settings = manager.getBot().getSettingsManager().getSettings(guildId);
+            
+            if (settings.getUseFairQueue())
+                return queue.add(qtrack);
+            else
+            {
+                queue.append(qtrack);
+                return queue.size()-1;
+            }
+        }
     }
     
     public FairQueue<QueuedTrack> getQueue()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/FairqueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/FairqueueCmd.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands.admin;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.commands.AdminCommand;
+import com.jagrosh.jmusicbot.settings.Settings;
+
+/**
+ *
+ * @author Brian Kendall
+ */
+public class FairqueueCmd extends AdminCommand
+{
+    public FairqueueCmd(Bot bot)
+    {
+        this.name = "fairqueue";
+        this.help = "turns fair queue on or off";
+        this.arguments = "[off|on]";
+        this.aliases = bot.getConfig().getAliases(this.name);
+    }
+    
+    @Override
+    protected void execute(CommandEvent event) 
+    {
+        String args = event.getArgs();
+        boolean value = true;
+        Settings settings = event.getClient().getSettingsFor(event.getGuild());
+        if(args.isEmpty())
+        {
+            value = !settings.getUseFairQueue();
+        }
+        else if(args.equalsIgnoreCase("false") || args.equalsIgnoreCase("off"))
+        {
+            value = false;
+        }
+        else if(args.equalsIgnoreCase("true") || args.equalsIgnoreCase("on"))
+        {
+            value = true;
+        }
+        else
+        {
+            event.replyError("Valid options are `off` or `on` (or leave empty to toggle between `off` and `on`)");
+            return;
+        }
+        settings.setUseFairQueue(value);
+        event.replySuccess("Fair queue is now `"+(value ? "on" : "off")+"`");
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
@@ -55,6 +55,11 @@ public class FairQueue<T extends Queueable> {
             list.add(index, item);
     }
     
+    public void append(T item)
+    {
+        list.add(item);
+    }
+    
     public int size()
     {
         return list.size();

--- a/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
@@ -38,8 +38,9 @@ public class Settings implements GuildSettingsProvider
     private RepeatMode repeatMode;
     private String prefix;
     private double skipRatio;
+    private boolean useFairQueue;
 
-    public Settings(SettingsManager manager, String textId, String voiceId, String roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix, double skipRatio)
+    public Settings(SettingsManager manager, String textId, String voiceId, String roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix, double skipRatio, boolean useFairQueue)
     {
         this.manager = manager;
         try
@@ -71,9 +72,10 @@ public class Settings implements GuildSettingsProvider
         this.repeatMode = repeatMode;
         this.prefix = prefix;
         this.skipRatio = skipRatio;
+        this.useFairQueue = useFairQueue;
     }
     
-    public Settings(SettingsManager manager, long textId, long voiceId, long roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix, double skipRatio)
+    public Settings(SettingsManager manager, long textId, long voiceId, long roleId, int volume, String defaultPlaylist, RepeatMode repeatMode, String prefix, double skipRatio, boolean useFairQueue)
     {
         this.manager = manager;
         this.textId = textId;
@@ -84,6 +86,7 @@ public class Settings implements GuildSettingsProvider
         this.repeatMode = repeatMode;
         this.prefix = prefix;
         this.skipRatio = skipRatio;
+        this.useFairQueue = useFairQueue;
     }
     
     // Getters
@@ -125,6 +128,11 @@ public class Settings implements GuildSettingsProvider
     public double getSkipRatio()
     {
         return skipRatio;
+    }
+    
+    public boolean getUseFairQueue()
+    {
+        return useFairQueue;
     }
 
     @Override
@@ -179,6 +187,12 @@ public class Settings implements GuildSettingsProvider
     public void setSkipRatio(double skipRatio)
     {
         this.skipRatio = skipRatio;
+        this.manager.writeSettings();
+    }
+
+    public void setUseFairQueue(boolean useFairQueue)
+    {
+        this.useFairQueue = useFairQueue;
         this.manager.writeSettings();
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -55,7 +55,8 @@ public class SettingsManager implements GuildSettingsManager
                         o.has("default_playlist")? o.getString("default_playlist")           : null,
                         o.has("repeat_mode")     ? o.getEnum(RepeatMode.class, "repeat_mode"): RepeatMode.OFF,
                         o.has("prefix")          ? o.getString("prefix")                     : null,
-                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
+                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO,
+                        o.has("use_fair_queue")  ? o.getBoolean("use_fair_queue")            : true));
             });
         } catch(IOException | JSONException e) {
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
@@ -81,7 +82,7 @@ public class SettingsManager implements GuildSettingsManager
     
     private Settings createDefaultSettings()
     {
-        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, SKIP_RATIO);
+        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, SKIP_RATIO, true);
     }
     
     protected void writeSettings()
@@ -106,6 +107,8 @@ public class SettingsManager implements GuildSettingsManager
                 o.put("prefix", s.getPrefix());
             if(s.getSkipRatio() != SKIP_RATIO)
                 o.put("skip_ratio", s.getSkipRatio());
+            if(!s.getUseFairQueue())
+                o.put("use_fair_queue", false);
             obj.put(Long.toString(key), o);
         });
         try {


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [X] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Adds an admin command for enabling or disabling fair queuing. When disabled, all tracks are added to the end of the queue, regardless of who queued them up. (Defaults to on, maintaining current behavior.)

### Purpose
Not everyone wants to use a fair queuing system, and instead would prefer a first-in-first-out queue.

### Relevant Issue(s)
#922 although it is already closed. I didn't see any changes to the code suggesting this feature had been added, though.
