### PR TITLE
Automatically show "now playing" when a new track starts

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -42,7 +42,7 @@ public class BotConfig
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
-    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
+    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots, autoNowPlaying;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private OnlineStatus status;
     private Activity game;
@@ -90,6 +90,7 @@ public class BotConfig
             status = OtherUtil.parseStatus(config.getString("status"));
             stayInChannel = config.getBoolean("stayinchannel");
             songInGame = config.getBoolean("songinstatus");
+            autoNowPlaying = config.getBoolean("autonowplaying");
             npImages = config.getBoolean("npimages");
             updatealerts = config.getBoolean("updatealerts");
             useEval = config.getBoolean("eval");
@@ -264,6 +265,11 @@ public class BotConfig
     public boolean getSongInStatus()
     {
         return songInGame;
+    }
+    
+    public boolean getAutoNowPlaying()
+    {
+        return autoNowPlaying;
     }
     
     public String getPlaylistsFolder()

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -195,7 +195,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
 
     
     // Formatting
-    public Message getNowPlaying(JDA jda)
+    public Message getNowPlaying(JDA jda, boolean includeProgress)
     {
         if(isMusicPlaying(jda))
         {
@@ -232,15 +232,26 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
             if(track.getInfo().author != null && !track.getInfo().author.isEmpty())
                 eb.setFooter("Source: " + track.getInfo().author, null);
 
-            double progress = (double)audioPlayer.getPlayingTrack().getPosition()/track.getDuration();
-            eb.setDescription((audioPlayer.isPaused() ? JMusicBot.PAUSE_EMOJI : JMusicBot.PLAY_EMOJI)
-                    + " "+FormatUtil.progressBar(progress)
-                    + " `[" + FormatUtil.formatTime(track.getPosition()) + "/" + FormatUtil.formatTime(track.getDuration()) + "]` "
-                    + FormatUtil.volumeIcon(audioPlayer.getVolume()));
+            if(includeProgress)
+            {
+                double progress = (double)audioPlayer.getPlayingTrack().getPosition()/track.getDuration();
+                eb.setDescription((audioPlayer.isPaused() ? JMusicBot.PAUSE_EMOJI : JMusicBot.PLAY_EMOJI)
+                        + " "+FormatUtil.progressBar(progress)
+                        + " `[" + FormatUtil.formatTime(track.getPosition()) + "/" + FormatUtil.formatTime(track.getDuration()) + "]` "
+                        + FormatUtil.volumeIcon(audioPlayer.getVolume()));
+            }
+            else
+                eb.setDescription(" `[" + FormatUtil.formatTime(track.getDuration()) + "]` "
+                        + FormatUtil.volumeIcon(audioPlayer.getVolume()));
             
             return mb.setEmbed(eb.build()).build();
         }
         else return null;
+    }
+    
+    public Message getNowPlaying(JDA jda)
+    {
+        return getNowPlaying(jda, true);
     }
     
     public Message getNoMusicPlaying(JDA jda)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -92,6 +92,13 @@ npimages = false
 stayinchannel = false
 
 
+// If you set this, the bot will automatically send a message displaying the current
+// track and which user queued it when a track starts playing for guilds that have
+// set a text channel for music commands.
+
+autonowplaying = false
+
+
 // This sets the maximum amount of seconds any track loaded can be. If not set or set
 // to any number less than or equal to zero, there is no maximum time length. This time
 // restriction applies to songs loaded from any source.


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [X] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds a bot setting `autonowplaying` that will make the bot automatically send a "now playing" text message when a new track starts, for any guild that has configured a text channel using the `settc` command. The setting defaults to off.

If `npimages` is true then the now playing message will not include a progress bar since it will always be at 00:00 and will never update.

### Purpose
For communities that want to see what the currently playing track is in their text channel's messages, similar to other music bots.

This provides another mechanism for users to easily see what the currently playing track is and, in particular, when the track changes. Aside from users preferring this method, this could also be useful for use cases where it's not possible to set the bot's status or not feasible to set the channel's topic (for example due to not having permission from the server or due to Discord's rate limiting).

### Relevant Issue(s)
#353 
