### PR TITLE
[Issue 285] Alphabetize Playlists in PlaylistsCmd & PlaylistCmd

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -34,11 +34,15 @@ public class PlaylistsCmd extends MusicCommand
         this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
         this.beListening = false;
-        this.beListening = false;
     }
     
     @Override
     public void doCommand(CommandEvent event) 
+    {
+        this.replyList(event, true);
+    }
+
+    public void replyList(CommandEvent event, boolean showInstructions)
     {
         if(!bot.getPlaylistLoader().folderExists())
             bot.getPlaylistLoader().createFolder();
@@ -56,7 +60,8 @@ public class PlaylistsCmd extends MusicCommand
         {
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
             list.forEach(str -> builder.append("`").append(str).append("` "));
-            builder.append("\nType `").append(event.getClient().getTextualPrefix()).append("play playlist <name>` to play a playlist");
+            if (showInstructions)
+                builder.append("\nType `").append(event.getClient().getTextualPrefix()).append("play playlist <name>` to play a playlist");
             event.reply(builder.toString());
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -40,19 +40,22 @@ public class PlaylistsCmd extends MusicCommand
     @Override
     public void doCommand(CommandEvent event) 
     {
-        this.replyList(event, true);
+        this.replyList(event, bot.getPlaylistLoader(), true);
     }
 
-    public void replyList(CommandEvent event, boolean showInstructions)
+    public static void replyList(CommandEvent event, PlaylistLoader loader, boolean showInstructions)
     {
-        if(!bot.getPlaylistLoader().folderExists())
-            bot.getPlaylistLoader().createFolder();
-        if(!bot.getPlaylistLoader().folderExists())
+        if (!loader.folderExists())
         {
-            event.reply(event.getClient().getWarning()+" Playlists folder does not exist and could not be created!");
+            loader.createFolder();
+        }
+        if (!loader.folderExists())
+        {
+            event.reply(event.getclient().getWarning() + " Plyalists folder does not exist and could not be created!");
             return;
         }
-        List<String> list = bot.getPlaylistLoader().getPlaylistNames();
+
+        List<String> list = loader.getPlaylistNames();
         if(list==null)
             event.reply(event.getClient().getError()+" Failed to load available playlists!");
         else if(list.isEmpty())
@@ -62,7 +65,7 @@ public class PlaylistsCmd extends MusicCommand
             Collections.sort(list);
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
             list.forEach(str -> builder.append("`").append(str).append("` "));
-            if (showInstructions) 
+            if (showInstructions)
             {
                 builder.append("\nType `").append(event.getClient().getTextualPrefix()).append("play playlist <name>` to play a playlist");
             }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -62,7 +62,8 @@ public class PlaylistsCmd extends MusicCommand
             Collections.sort(list);
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
             list.forEach(str -> builder.append("`").append(str).append("` "));
-            if (showInstructions) {
+            if (showInstructions) 
+            {
                 builder.append("\nType `").append(event.getClient().getTextualPrefix()).append("play playlist <name>` to play a playlist");
             }
             event.reply(builder.toString());

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -62,8 +62,9 @@ public class PlaylistsCmd extends MusicCommand
             Collections.sort(list);
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
             list.forEach(str -> builder.append("`").append(str).append("` "));
-            if (showInstructions)
+            if (showInstructions) {
                 builder.append("\nType `").append(event.getClient().getTextualPrefix()).append("play playlist <name>` to play a playlist");
+            }
             event.reply(builder.toString());
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -16,6 +16,7 @@
 package com.jagrosh.jmusicbot.commands.music;
 
 import java.util.List;
+import java.util.Collections;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
@@ -58,6 +59,7 @@ public class PlaylistsCmd extends MusicCommand
             event.reply(event.getClient().getWarning()+" There are no playlists in the Playlists folder!");
         else
         {
+            Collections.sort(list);
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
             list.forEach(str -> builder.append("`").append(str).append("` "));
             if (showInstructions)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -16,11 +16,11 @@
 package com.jagrosh.jmusicbot.commands.owner;
 
 import java.io.IOException;
-import java.util.List;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
+import com.jagrosh.jmusicbot.commands.music.PlaylistsCmd;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
 
 /**
@@ -195,24 +195,7 @@ public class PlaylistCmd extends OwnerCommand
         @Override
         protected void execute(CommandEvent event) 
         {
-            if(!bot.getPlaylistLoader().folderExists())
-                bot.getPlaylistLoader().createFolder();
-            if(!bot.getPlaylistLoader().folderExists())
-            {
-                event.reply(event.getClient().getWarning()+" Playlists folder does not exist and could not be created!");
-                return;
-            }
-            List<String> list = bot.getPlaylistLoader().getPlaylistNames();
-            if(list==null)
-                event.reply(event.getClient().getError()+" Failed to load available playlists!");
-            else if(list.isEmpty())
-                event.reply(event.getClient().getWarning()+" There are no playlists in the Playlists folder!");
-            else
-            {
-                StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");
-                list.forEach(str -> builder.append("`").append(str).append("` "));
-                event.reply(builder.toString());
-            }
+            new PlaylistsCmd(bot).replyList(event, false);
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -195,7 +195,7 @@ public class PlaylistCmd extends OwnerCommand
         @Override
         protected void execute(CommandEvent event) 
         {
-            new PlaylistsCmd(bot).replyList(event, false);
+            PlaylistsCmd.replyList(event, bot.getPlaylistLoader(), false);
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -58,8 +58,6 @@ public class SettingsManager implements GuildSettingsManager
                         o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
             });
         } catch(IOException | JSONException e) {
-            if (System.getProperty("serversettings.suppressFirstLoadWarning", "false").equalsIgnoreCase("true"))
-                return;
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -58,6 +58,8 @@ public class SettingsManager implements GuildSettingsManager
                         o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
             });
         } catch(IOException | JSONException e) {
+            if (System.getProperty("serversettings.suppressFirstLoadWarning", "false").equalsIgnoreCase("true"))
+                return;
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
         }
     }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [x] Boosts code quality or performance

### Description

This appears to be not an issue on many systems, as files are already alphabetized and playlists are stored in files.  This PR enforces alphabetization via sort. However `File.listFiles()` _does not guarantee alphabetization _

Additionally, this PR deduplicates a several lines of code shared between `PlaylistCmd` and `PlaylistsCmd`.

This is all contained in just 2 commits for step-by-step review.

![image](https://user-images.githubusercontent.com/36784267/140627025-cc870e03-f582-416b-85e1-bff8cb7fb8ba.png)

#### Why add that system property?

Unit testing logs were very bloated if you try to make them pure with `@Before`/`@After`.  This is an alternative to introducing a `serversettings.file` property since that was a complex change.

The unit tests were abandoned due to excessive complexity not worth it for the simplicity of this feature.  But here's what I had built.


![image](https://user-images.githubusercontent.com/36784267/140627026-7ec7a200-dc3c-4ddc-8e29-2014f79424fe.png)

![testUnit1](https://user-images.githubusercontent.com/36784267/140626939-20e3de5f-659f-49d9-9b04-e23b395cbf5e.JPG)


### Purpose
Enforce alphabetical order of playlist results.

### Relevant Issue(s)
This PR closes issue #285 
