### PR TITLE
Queue links

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/QueuedTrack.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/QueuedTrack.java
@@ -53,6 +53,6 @@ public class QueuedTrack implements Queueable
     @Override
     public String toString() 
     {
-        return "`[" + FormatUtil.formatTime(track.getDuration()) + "]` **" + track.getInfo().title + "** - <@" + track.getUserData(RequestMetadata.class).getOwner() + ">";
+        return "`[" + FormatUtil.formatTime(track.getDuration()) + "]` [**" + track.getInfo().title + "**]("+track.getInfo().uri+") - <@" + track.getUserData(RequestMetadata.class).getOwner() + ">";
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -91,7 +91,7 @@ public class QueueCmd extends MusicCommand
         for(int i=0; i<list.size(); i++)
         {
             total += list.get(i).getTrack().getDuration();
-            songs[i] = "`["+FormatUtil.formatTime(list.get(i).getTrack().getDuration())+"]` [**"+list.get(i).getTrack().getInfo().title+"**]("+list.get(i).getTrack().getInfo().uri+")";
+            songs[i] = list.get(i).toString();
         }
         Settings settings = event.getClient().getSettingsFor(event.getGuild());
         long fintotal = total;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -91,7 +91,7 @@ public class QueueCmd extends MusicCommand
         for(int i=0; i<list.size(); i++)
         {
             total += list.get(i).getTrack().getDuration();
-            songs[i] = list.get(i).toString();
+            songs[i] = "`["+FormatUtil.formatTime(list.get(i).getTrack().getDuration())+"]` [**"+list.get(i).getTrack().getInfo().title+"**]("+list.get(i).getTrack().getInfo().uri+")";
         }
         Settings settings = event.getClient().getSettingsFor(event.getGuild());
         long fintotal = total;


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
I have slightly edited the queue command so that the list of queued track names it returns can be clicked on.

This is what it used to look like:
![image](https://user-images.githubusercontent.com/64579257/141385817-9f50056d-9f9e-4987-a613-e5e0752efa52.png)

And this is the new look:
![image](https://user-images.githubusercontent.com/64579257/141385896-e8171ffe-1075-4fb6-b24f-a616df649fc5.png)

(Similar to the search command)
![image](https://user-images.githubusercontent.com/64579257/141386401-4bcd2e61-1cbf-4883-8ad3-cfb5a4af33f8.png)

### Purpose
Often times I use the queue command and want to check upcoming songs, but other than the track name, duration and requester, there isn't a lot more information. Now the track name can be clicked on and you will be taken to the track source (like YouTube) to see more details. 