### PR TITLE
[FEATURE] Adding join for switching channels - bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.json
 *.txt
 nb*.xml
+JMusicBot.iml
+.idea

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -112,6 +112,7 @@ public class JMusicBot
 
                         new ForceRemoveCmd(bot),
                         new ForceskipCmd(bot),
+                        new JoinCmd(bot),
                         new MoveTrackCmd(bot),
                         new PauseCmd(bot),
                         new PlaynextCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
@@ -30,7 +30,7 @@ public abstract class DJCommand extends MusicCommand
     public DJCommand(Bot bot)
     {
         super(bot);
-        this.category = new Category("DJ", event -> checkDJPermission(event));
+        this.category = new Category("DJ", DJCommand::checkDJPermission);
     }
     
     public static boolean checkDJPermission(CommandEvent event)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands.dj;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.commands.DJCommand;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.exceptions.PermissionException;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ *
+ * @author UnrealValentin
+ */
+public class JoinCmd extends DJCommand
+{
+
+    public JoinCmd(Bot bot)
+    {
+        super(bot);
+        this.name = "join";
+        this.help = "makes the bot join a voice channel";
+        this.arguments = "[channel]";
+        this.aliases = bot.getConfig().getAliases(this.name);
+        this.bePlaying = false;
+        this.beListening = false;
+    }
+
+    @Override
+    public void doCommand(CommandEvent event)
+    {
+
+        AudioManager manager = event.getGuild().getAudioManager();
+        VoiceChannel vc;
+
+        if(event.getArgs().isEmpty()) {
+
+            vc = Objects.requireNonNull(event.getMember().getVoiceState()).getChannel();
+
+        } else {
+
+            // I made the code simple cause I don't think someone will have multiple channels with the same name...
+            // I just hope we don't need a menu like in search here!
+
+            Optional<VoiceChannel> maybe = event.getGuild().getVoiceChannels().stream()
+                    .filter(voiceChannel -> voiceChannel.getName().equalsIgnoreCase(event.getArgs())).findFirst();
+
+            if(maybe.isPresent()) {
+                vc = maybe.get();
+            } else {
+                event.reply(":x: Channel not found! Check your spelling!");
+                return;
+            }
+
+        }
+
+        if (vc == null) {
+            event.reply(":x: You need to be in a channel to use this or provide a Voice Channel for the bot to join!");
+        }
+
+        try {
+            manager.openAudioConnection(vc);
+        } catch (PermissionException permissionException) {
+            event.reply(event.getClient().getError()+" I am unable to connect to **"+vc.getName()+"**! I don't have the permissions!");
+            return;
+        }
+
+        event.reply("Joined " + vc.getName());
+
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
@@ -18,12 +18,14 @@ package com.jagrosh.jmusicbot.commands.dj;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.DJCommand;
+import com.jagrosh.jdautilities.commons.utils.FinderUtil;
+import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.managers.AudioManager;
 
 import java.util.Objects;
-import java.util.Optional;
+import java.util.List;
 
 /**
  *
@@ -50,39 +52,44 @@ public class JoinCmd extends DJCommand
         AudioManager manager = event.getGuild().getAudioManager();
         VoiceChannel vc;
 
-        if(event.getArgs().isEmpty()) {
-
+        if(event.getArgs().isEmpty()) 
+        {
             vc = Objects.requireNonNull(event.getMember().getVoiceState()).getChannel();
-
-        } else {
-
-            // I made the code simple cause I don't think someone will have multiple channels with the same name...
-            // I just hope we don't need a menu like in search here!
-
-            Optional<VoiceChannel> maybe = event.getGuild().getVoiceChannels().stream()
-                    .filter(voiceChannel -> voiceChannel.getName().equalsIgnoreCase(event.getArgs())).findFirst();
-
-            if(maybe.isPresent()) {
-                vc = maybe.get();
-            } else {
-                event.reply(":x: Channel not found! Check your spelling!");
-                return;
+        } 
+        else 
+        {
+            List<VoiceChannel> list = FinderUtil.findVoiceChannels(event.getArgs(), event.getGuild()); 
+                    
+            if(list.isEmpty())
+            { 
+                event.replyWarning("No Voice Channels found matching \""+event.getArgs()+"\"");
+            } 
+            else if (list.size()>1)
+            {
+                 event.replyWarning("Multiple Voice Channels found matching \""+event.getArgs()+"\"" + FormatUtil.listOfVChannels(list, event.getArgs()));
             }
+            else 
+            { 
+                vc = list.get(0);
+                
+                if (vc == null) 
+                {
+                    event.replyError(":x: You need to be in a channel to use this or provide a Voice Channel for the bot to join!");
+                    return;
+                }
 
+                try
+                {
+                    manager.openAudioConnection(vc);
+                } 
+                catch (PermissionException permissionException) 
+                {
+                    event.replyError(event.getClient().getError()+" I am unable to connect to **"+vc.getName()+"**! I don't have the permissions!");
+                    return;
+                }
+
+                event.replySuccess("Joined " + vc.getName());
+            }
         }
-
-        if (vc == null) {
-            event.reply(":x: You need to be in a channel to use this or provide a Voice Channel for the bot to join!");
-        }
-
-        try {
-            manager.openAudioConnection(vc);
-        } catch (PermissionException permissionException) {
-            event.reply(event.getClient().getError()+" I am unable to connect to **"+vc.getName()+"**! I don't have the permissions!");
-            return;
-        }
-
-        event.reply("Joined " + vc.getName());
-
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/JoinCmd.java
@@ -66,7 +66,7 @@ public class JoinCmd extends DJCommand
             } 
             else if (list.size()>1)
             {
-                 event.replyWarning("Multiple Voice Channels found matching \""+event.getArgs()+"\"" + FormatUtil.listOfVChannels(list, event.getArgs()));
+                 event.replyWarning(FormatUtil.listOfVChannels(list, event.getArgs()));
             }
             else 
             { 


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [X] Introduces a new feature
  - [ ] Improves an existing feature
  - [X] Boosts code quality or performance

### Description
Added JoinCmd to switch channels when music plays for djs.
Also added intellij stuff to gitignore and shortened something in DJCommand

### Purpose
If you are a dj and want to switch channels and don't have move permissions you couldn't switch the music bots channel without disconnectiong which closes the queue. Now you can just switch chanels with join!

### Relevant Issue(s)
This change was implemented in: https://github.com/jagrosh/MusicBot/pull/595. This PR applies the review comments from the maintainer since there has been no response on the original PR.
This PR closes a thing on the road map.
