### PR TITLE
Fixes #514 Require inputing name for `playlist make <name>` command

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -75,11 +75,6 @@ public class PlaylistCmd extends OwnerCommand
             if(pname == null || pname.isEmpty()) 
             {
                 event.replyError("Please provide a name for the playlist!");
-                
-                StringBuilder builder = new StringBuilder(event.getClient().getWarning() + " Playlist Make Command:\n");
-                builder.append("\n`").append(event.getClient().getPrefix()).append(name)
-                        .append(" <name>` - creates a new, empty playlist with given name");
-                event.reply(builder.toString());
             } 
             else if(bot.getPlaylistLoader().getPlaylist(pname) == null)
             {

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -72,7 +72,16 @@ public class PlaylistCmd extends OwnerCommand
         protected void execute(CommandEvent event) 
         {
             String pname = event.getArgs().replaceAll("\\s+", "_");
-            if(bot.getPlaylistLoader().getPlaylist(pname)==null)
+            if(pname == null || pname.isEmpty()) 
+            {
+                event.reply(event.getClient().getError() + " Please provide a name for playlist!");
+                
+                StringBuilder builder = new StringBuilder(event.getClient().getWarning() + " Playlist Make Command:\n");
+                builder.append("\n`").append(event.getClient().getPrefix()).append(name)
+                        .append(" <name>` - creates a new, empty playlist with given name");
+                event.reply(builder.toString());
+            } 
+            else if(bot.getPlaylistLoader().getPlaylist(pname) == null)
             {
                 try
                 {

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -74,7 +74,7 @@ public class PlaylistCmd extends OwnerCommand
             String pname = event.getArgs().replaceAll("\\s+", "_");
             if(pname == null || pname.isEmpty()) 
             {
-                event.reply(event.getClient().getError() + " Please provide a name for playlist!");
+                event.replyError("Please provide a name for the playlist!");
                 
                 StringBuilder builder = new StringBuilder(event.getClient().getWarning() + " Playlist Make Command:\n");
                 builder.append("\n`").append(event.getClient().getPrefix()).append(name)


### PR DESCRIPTION
playlist make command without a name will now not make an empty playlist without a playlist name.

### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Checks whether we have obtained a name from the user for generating a new, empty playlist. If not, we ask for a name.

### Purpose
Fix bug #514 where empty playlists with no name can be created

### Relevant Issue(s)
This PR closes issue #514 
