### PR TITLE
ft: provide useful information when set commands are made with no argument

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -59,7 +59,7 @@ public abstract class MusicCommand extends Command
         bot.getPlayerManager().setUpHandler(event.getGuild()); // no point constantly checking for this later
         if(bePlaying && !((AudioHandler)event.getGuild().getAudioManager().getSendingHandler()).isMusicPlaying(event.getJDA()))
         {
-            event.reply(event.getClient().getError()+" There must be music playing to use that!");
+            event.replyError("There must be music playing to use that!");
             return;
         }
         if(beListening)
@@ -89,7 +89,7 @@ public abstract class MusicCommand extends Command
                 }
                 catch(PermissionException ex) 
                 {
-                    event.reply(event.getClient().getError()+" I am unable to connect to "+userState.getChannel().getAsMention()+"!");
+                    event.replyError("I am unable to connect to "+userState.getChannel().getAsMention()+"!");
                     return;
                 }
             }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/PrefixCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/PrefixCmd.java
@@ -37,14 +37,19 @@ public class PrefixCmd extends AdminCommand
     @Override
     protected void execute(CommandEvent event) 
     {
+        Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().isEmpty())
         {
-            event.replyError("Please include a prefix or NONE");
-            return;
+            if (s.getPrefix() == null)
+            {
+                event.replySuccess("Custom prefix is currently set to `" + s.getPrefix() + "` on *" + event.getGuild().getName() + "*");
+            }
+            else
+            {
+                event.replySuccess("Custom prefix is currently unset");
+            }
         }
-        
-        Settings s = event.getClient().getSettingsFor(event.getGuild());
-        if(event.getArgs().equalsIgnoreCase("none"))
+        else if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setPrefix(null);
             event.replySuccess("Prefix cleared.");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/PrefixCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/PrefixCmd.java
@@ -42,11 +42,11 @@ public class PrefixCmd extends AdminCommand
         {
             if (s.getPrefix() == null)
             {
-                event.replySuccess("Custom prefix is currently set to `" + s.getPrefix() + "` on *" + event.getGuild().getName() + "*");
+                event.replySuccess("Custom prefix is currently unset");
             }
             else
             {
-                event.replySuccess("Custom prefix is currently unset");
+                event.replySuccess("Custom prefix is currently set to `" + s.getPrefix() + "` on *" + event.getGuild().getName() + "*");
             }
         }
         else if(event.getArgs().equalsIgnoreCase("none"))

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -43,26 +43,26 @@ public class SetdjCmd extends AdminCommand
     {
         if(event.getArgs().isEmpty())
         {
-            event.reply(event.getClient().getError()+" Please include a role name or NONE");
+            event.replyError("Please include a role name or NONE");
             return;
         }
         Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setDJRole(null);
-            event.reply(event.getClient().getSuccess()+" DJ role cleared; Only Admins can use the DJ commands.");
+            event.replySuccess("DJ role cleared; Only Admins can use the DJ commands.");
         }
         else
         {
             List<Role> list = FinderUtil.findRoles(event.getArgs(), event.getGuild());
             if(list.isEmpty())
-                event.reply(event.getClient().getWarning()+" No Roles found matching \""+event.getArgs()+"\"");
+                event.replyWarning("No Roles found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)
                 event.reply(event.getClient().getWarning()+FormatUtil.listOfRoles(list, event.getArgs()));
             else
             {
                 s.setDJRole(list.get(0));
-                event.reply(event.getClient().getSuccess()+" DJ commands can now be used by users with the **"+list.get(0).getName()+"** role.");
+                event.replySuccess("DJ commands can now be used by users with the **"+list.get(0).getName()+"** role.");
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -58,7 +58,7 @@ public class SetdjCmd extends AdminCommand
             if(list.isEmpty())
                 event.replyWarning("No Roles found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)
-                event.reply(event.getClient().getWarning()+FormatUtil.listOfRoles(list, event.getArgs()));
+                event.replyWarning(FormatUtil.listOfRoles(list, event.getArgs()));
             else
             {
                 s.setDJRole(list.get(0));

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -41,13 +41,19 @@ public class SetdjCmd extends AdminCommand
     @Override
     protected void execute(CommandEvent event) 
     {
+        Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().isEmpty())
         {
-            event.replyError("Please include a role name or NONE");
-            return;
+            if (s.getRole(event.getGuild()) == null)
+            {
+                event.replySuccess("DJ role is currently cleared; Only Admins can use the DJ commands.");
+            }
+            else
+            {
+                event.replySuccess("DJ commands can currently be used by users with the **"+s.getRole(event.getGuild())+"** role.");
+            }
         }
-        Settings s = event.getClient().getSettingsFor(event.getGuild());
-        if(event.getArgs().equalsIgnoreCase("none"))
+        else if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setDJRole(null);
             event.replySuccess("DJ role cleared; Only Admins can use the DJ commands.");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetdjCmd.java
@@ -50,7 +50,7 @@ public class SetdjCmd extends AdminCommand
             }
             else
             {
-                event.replySuccess("DJ commands can currently be used by users with the **"+s.getRole(event.getGuild())+"** role.");
+                event.replySuccess("DJ commands can currently be used by users with the **"+s.getRole(event.getGuild()).getName()+"** role.");
             }
         }
         else if(event.getArgs().equalsIgnoreCase("none"))

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -41,13 +41,19 @@ public class SettcCmd extends AdminCommand
     @Override
     protected void execute(CommandEvent event) 
     {
+        Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().isEmpty())
         {
-            event.replyError("Please include a text channel or NONE");
-            return;
+            if (s.getTextChannel(event.getGuild()) == null)
+            {
+                event.replySuccess("Music commands can currently be used in any channel");
+            }
+            else
+            {
+                event.replySuccess("Music commands can currently only be used in <#"+s.getTextChannel(event.getGuild())+">");
+            }
         }
-        Settings s = event.getClient().getSettingsFor(event.getGuild());
-        if(event.getArgs().equalsIgnoreCase("none"))
+        else if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setTextChannel(null);
             event.replySuccess("Music commands can now be used in any channel");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -43,26 +43,26 @@ public class SettcCmd extends AdminCommand
     {
         if(event.getArgs().isEmpty())
         {
-            event.reply(event.getClient().getError()+" Please include a text channel or NONE");
+            event.replyError("Please include a text channel or NONE");
             return;
         }
         Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setTextChannel(null);
-            event.reply(event.getClient().getSuccess()+" Music commands can now be used in any channel");
+            event.replySuccess("Music commands can now be used in any channel");
         }
         else
         {
             List<TextChannel> list = FinderUtil.findTextChannels(event.getArgs(), event.getGuild());
             if(list.isEmpty())
-                event.reply(event.getClient().getWarning()+" No Text Channels found matching \""+event.getArgs()+"\"");
+                event.replyWarning("No Text Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)
-                event.reply(event.getClient().getWarning()+FormatUtil.listOfTChannels(list, event.getArgs()));
+                event.replyWarning(FormatUtil.listOfTChannels(list, event.getArgs()));
             else
             {
                 s.setTextChannel(list.get(0));
-                event.reply(event.getClient().getSuccess()+" Music commands can now only be used in <#"+list.get(0).getId()+">");
+                event.replySuccess("Music commands can now only be used in <#"+list.get(0).getId()+">");
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -50,7 +50,7 @@ public class SettcCmd extends AdminCommand
             }
             else
             {
-                event.replySuccess("Music commands can currently only be used in <#"+s.getTextChannel(event.getGuild())+">");
+                event.replySuccess("Music commands can currently only be used in "+s.getTextChannel(event.getGuild()).getAsMention());
             }
         }
         else if(event.getArgs().equalsIgnoreCase("none"))
@@ -68,7 +68,7 @@ public class SettcCmd extends AdminCommand
             else
             {
                 s.setTextChannel(list.get(0));
-                event.replySuccess("Music commands can now only be used in <#"+list.get(0).getId()+">");
+                event.replySuccess("Music commands can now only be used in "+list.get(0).getAsMention());
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -41,13 +41,20 @@ public class SetvcCmd extends AdminCommand
     @Override
     protected void execute(CommandEvent event) 
     {
+        Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().isEmpty())
         {
-            event.replyError("Please include a voice channel or NONE");
-            return;
+            if (s.getVoiceChannel(event.getGuild()) == null)
+            {
+                event.replySuccess("Music can currently be played in any channel");
+            }
+            else
+            {
+                event.replySuccess("Music can currently only be played in "+s.getVoiceChannel(event.getGuild()).getAsMention());
+
+            }
         }
-        Settings s = event.getClient().getSettingsFor(event.getGuild());
-        if(event.getArgs().equalsIgnoreCase("none"))
+        else if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setVoiceChannel(null);
             event.replySuccess("Music can now be played in any channel");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -43,26 +43,26 @@ public class SetvcCmd extends AdminCommand
     {
         if(event.getArgs().isEmpty())
         {
-            event.reply(event.getClient().getError()+" Please include a voice channel or NONE");
+            event.replyError("Please include a voice channel or NONE");
             return;
         }
         Settings s = event.getClient().getSettingsFor(event.getGuild());
         if(event.getArgs().equalsIgnoreCase("none"))
         {
             s.setVoiceChannel(null);
-            event.reply(event.getClient().getSuccess()+" Music can now be played in any channel");
+            event.replySuccess("Music can now be played in any channel");
         }
         else
         {
             List<VoiceChannel> list = FinderUtil.findVoiceChannels(event.getArgs(), event.getGuild());
             if(list.isEmpty())
-                event.reply(event.getClient().getWarning()+" No Voice Channels found matching \""+event.getArgs()+"\"");
+                event.replyWarning("No Voice Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)
                 event.reply(event.getClient().getWarning()+FormatUtil.listOfVChannels(list, event.getArgs()));
             else
             {
                 s.setVoiceChannel(list.get(0));
-                event.reply(event.getClient().getSuccess()+" Music can now only be played in "+list.get(0).getAsMention());
+                event.replySuccess("Music can now only be played in "+list.get(0).getAsMention());
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -58,7 +58,7 @@ public class SetvcCmd extends AdminCommand
             if(list.isEmpty())
                 event.replyWarning("No Voice Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)
-                event.reply(event.getClient().getWarning()+FormatUtil.listOfVChannels(list, event.getArgs()));
+                event.replyWarning(FormatUtil.listOfVChannels(list, event.getArgs()));
             else
             {
                 s.setVoiceChannel(list.get(0));

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SkipratioCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SkipratioCmd.java
@@ -33,29 +33,32 @@ public class SkipratioCmd extends AdminCommand
         this.arguments = "<0 - 100>";
         this.aliases = bot.getConfig().getAliases(this.name);
     }
-    
+
     @Override
-    protected void execute(CommandEvent event) 
+    protected void execute(CommandEvent event)
     {
         Settings s = event.getClient().getSettingsFor(event.getGuild());
         if (event.getArgs().isEmpty())
         {
             event.replySuccess("Skip percentage is currently set to `" + Math.round(s.getSkipRatio() * 100) + "%` of listeners on *" + event.getGuild().getName() + "*");
         }
-        try
+        else
         {
-            int val = Integer.parseInt(event.getArgs().endsWith("%") ? event.getArgs().substring(0,event.getArgs().length()-1) : event.getArgs());
-            if( val < 0 || val > 100)
+            try
             {
-                event.replyError("The provided value must be between 0 and 100!");
-                return;
+                int val = Integer.parseInt(event.getArgs().endsWith("%") ? event.getArgs().substring(0, event.getArgs().length() - 1) : event.getArgs());
+                if (val < 0 || val > 100)
+                {
+                    event.replyError("The provided value must be between 0 and 100!");
+                    return;
+                }
+                s.setSkipRatio(val / 100.0);
+                event.replySuccess("Skip percentage has been set to `" + val + "%` of listeners on *" + event.getGuild().getName() + "*");
             }
-            s.setSkipRatio(val / 100.0);
-            event.replySuccess("Skip percentage has been set to `" + val + "%` of listeners on *" + event.getGuild().getName() + "*");
-        }
-        catch(NumberFormatException ex)
-        {
-            event.replyError("Please include an integer between 0 and 100 (default is 55). This number is the percentage of listening users that must vote to skip a song.");
+            catch (NumberFormatException ex)
+            {
+                event.replyError("Please include an integer between 0 and 100 (default is 55). This number is the percentage of listening users that must vote to skip a song.");
+            }
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SkipratioCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SkipratioCmd.java
@@ -37,6 +37,11 @@ public class SkipratioCmd extends AdminCommand
     @Override
     protected void execute(CommandEvent event) 
     {
+        Settings s = event.getClient().getSettingsFor(event.getGuild());
+        if (event.getArgs().isEmpty())
+        {
+            event.replySuccess("Skip percentage is currently set to `" + Math.round(s.getSkipRatio() * 100) + "%` of listeners on *" + event.getGuild().getName() + "*");
+        }
         try
         {
             int val = Integer.parseInt(event.getArgs().endsWith("%") ? event.getArgs().substring(0,event.getArgs().length()-1) : event.getArgs());
@@ -45,7 +50,6 @@ public class SkipratioCmd extends AdminCommand
                 event.replyError("The provided value must be between 0 and 100!");
                 return;
             }
-            Settings s = event.getClient().getSettingsFor(event.getGuild());
             s.setSkipRatio(val / 100.0);
             event.replySuccess("Skip percentage has been set to `" + val + "%` of listeners on *" + event.getGuild().getName() + "*");
         }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceskipCmd.java
@@ -42,7 +42,7 @@ public class ForceskipCmd extends DJCommand
     {
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
         RequestMetadata rm = handler.getRequestMetadata();
-        event.reply(event.getClient().getSuccess()+" Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title
+        event.replySuccess("Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title
                 +"** "+(rm.getOwner() == 0L ? "(autoplay)" : "(requested by **" + rm.user.username + "**)"));
         handler.getPlayer().stopTrack();
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/SkiptoCmd.java
@@ -46,17 +46,17 @@ public class SkiptoCmd extends DJCommand
         }
         catch(NumberFormatException e)
         {
-            event.reply(event.getClient().getError()+" `"+event.getArgs()+"` is not a valid integer!");
+            event.replyError("`"+event.getArgs()+"` is not a valid integer!");
             return;
         }
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
         if(index<1 || index>handler.getQueue().size())
         {
-            event.reply(event.getClient().getError()+" Position must be a valid integer between 1 and "+handler.getQueue().size()+"!");
+            event.replyError("Position must be a valid integer between 1 and "+handler.getQueue().size()+"!");
             return;
         }
         handler.getQueue().skip(index-1);
-        event.reply(event.getClient().getSuccess()+" Skipped to **"+handler.getQueue().get(0).getTrack().getInfo().title+"**");
+        event.replySuccess("Skipped to **"+handler.getQueue().get(0).getTrack().getInfo().title+"**");
         handler.getPlayer().stopTrack();
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/StopCmd.java
@@ -41,6 +41,6 @@ public class StopCmd extends DJCommand
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
         handler.stopAndClear();
         event.getGuild().getAudioManager().closeAudioConnection();
-        event.reply(event.getClient().getSuccess()+" The player has stopped and the queue has been cleared.");
+        event.replySuccess("The player has stopped and the queue has been cleared.");
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/VolumeCmd.java
@@ -56,7 +56,7 @@ public class VolumeCmd extends DJCommand
                 nvolume = -1;
             }
             if(nvolume<0 || nvolume>150)
-                event.reply(event.getClient().getError()+" Volume must be a valid integer between 0 and 150!");
+                event.replyError("Volume must be a valid integer between 0 and 150!");
             else
             {
                 handler.getPlayer().setVolume(nvolume);

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -230,7 +230,7 @@ public class PlayCmd extends MusicCommand
         {
             if(event.getArgs().isEmpty())
             {
-                event.reply(event.getClient().getError()+" Please include a playlist name.");
+                event.replyError("Please include a playlist name.");
                 return;
             }
             Playlist playlist = bot.getPlaylistLoader().getPlaylist(event.getArgs());

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -84,14 +84,12 @@ public class PlayCmd extends MusicCommand
             event.reply(builder.toString());
             return;
         }
-        String args;
         if (!event.getArgs().isEmpty()){
-            args = event.getArgs().replaceAll("^<|>$", "");
+            String args = event.getArgs().replaceAll("^<|>$", "");
             event.reply(loadingEmoji + " Loading... `[" + args + "]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m, event, false)));
         } else{
             for (Message.Attachment attachment: event.getMessage().getAttachments()) {
-                args = attachment.getUrl();
-                event.reply(loadingEmoji + " Loading... `[" + args + "]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m, event, false)));
+                event.reply(loadingEmoji + " Loading... `[" + attachment.getUrl() + "]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), attachment.getUrl(), new ResultHandler(m, event, false)));
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -84,10 +84,16 @@ public class PlayCmd extends MusicCommand
             event.reply(builder.toString());
             return;
         }
-        String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">") 
-                ? event.getArgs().substring(1,event.getArgs().length()-1) 
-                : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
-        event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
+        String args;
+        if (!event.getArgs().isEmpty()){
+            args = event.getArgs().replaceAll("^<|>$", "");
+            event.reply(loadingEmoji + " Loading... `[" + args + "]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m, event, false)));
+        } else{
+            for (Message.Attachment attachment: event.getMessage().getAttachments()) {
+                args = attachment.getUrl();
+                event.reply(loadingEmoji + " Loading... `[" + args + "]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m, event, false)));
+            }
+        }
     }
     
     private class ResultHandler implements AudioLoadResultHandler

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -34,7 +34,6 @@ public class PlaylistsCmd extends MusicCommand
         this.aliases = bot.getConfig().getAliases(this.name);
         this.guildOnly = true;
         this.beListening = false;
-        this.beListening = false;
     }
     
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlaylistsCmd.java
@@ -44,14 +44,14 @@ public class PlaylistsCmd extends MusicCommand
             bot.getPlaylistLoader().createFolder();
         if(!bot.getPlaylistLoader().folderExists())
         {
-            event.reply(event.getClient().getWarning()+" Playlists folder does not exist and could not be created!");
+            event.replyWarning("Playlists folder does not exist and could not be created!");
             return;
         }
         List<String> list = bot.getPlaylistLoader().getPlaylistNames();
         if(list==null)
-            event.reply(event.getClient().getError()+" Failed to load available playlists!");
+            event.replyError("Failed to load available playlists!");
         else if(list.isEmpty())
-            event.reply(event.getClient().getWarning()+" There are no playlists in the Playlists folder!");
+            event.replyWarning("There are no playlists in the Playlists folder!");
         else
         {
             StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -45,7 +45,7 @@ public class SkipCmd extends MusicCommand
         RequestMetadata rm = handler.getRequestMetadata();
         if(event.getAuthor().getIdLong() == rm.getOwner())
         {
-            event.reply(event.getClient().getSuccess()+" Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title+"**");
+            event.replySuccess("Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title+"**");
             handler.getPlayer().stopTrack();
         }
         else

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/AutoplaylistCmd.java
@@ -43,26 +43,26 @@ public class AutoplaylistCmd extends OwnerCommand
     {
         if(event.getArgs().isEmpty())
         {
-            event.reply(event.getClient().getError()+" Please include a playlist name or NONE");
+            event.replyError("Please include a playlist name or NONE");
             return;
         }
         if(event.getArgs().equalsIgnoreCase("none"))
         {
             Settings settings = event.getClient().getSettingsFor(event.getGuild());
             settings.setDefaultPlaylist(null);
-            event.reply(event.getClient().getSuccess()+" Cleared the default playlist for **"+event.getGuild().getName()+"**");
+            event.replySuccess("Cleared the default playlist for **"+event.getGuild().getName()+"**");
             return;
         }
         String pname = event.getArgs().replaceAll("\\s+", "_");
         if(bot.getPlaylistLoader().getPlaylist(pname)==null)
         {
-            event.reply(event.getClient().getError()+" Could not find `"+pname+".txt`!");
+            event.replyError("Could not find `"+pname+".txt`!");
         }
         else
         {
             Settings settings = event.getClient().getSettingsFor(event.getGuild());
             settings.setDefaultPlaylist(pname);
-            event.reply(event.getClient().getSuccess()+" The default playlist for **"+event.getGuild().getName()+"** is now `"+pname+"`");
+            event.replySuccess("The default playlist for **"+event.getGuild().getName()+"** is now `"+pname+"`");
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
@@ -49,11 +49,11 @@ public class EvalCmd extends OwnerCommand
         se.put("channel", event.getChannel());
         try
         {
-            event.reply(event.getClient().getSuccess()+" Evaluated Successfully:\n```\n"+se.eval(event.getArgs())+" ```");
+            event.replySuccess("Evaluated Successfully:\n```\n"+se.eval(event.getArgs())+" ```");
         } 
         catch(Exception e)
         {
-            event.reply(event.getClient().getError()+" An exception was thrown:\n```\n"+e+" ```");
+            event.replyError("An exception was thrown:\n```\n"+e+" ```");
         }
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -77,15 +77,15 @@ public class PlaylistCmd extends OwnerCommand
                 try
                 {
                     bot.getPlaylistLoader().createPlaylist(pname);
-                    event.reply(event.getClient().getSuccess()+" Successfully created playlist `"+pname+"`!");
+                    event.replySuccess("Successfully created playlist `"+pname+"`!");
                 }
                 catch(IOException e)
                 {
-                    event.reply(event.getClient().getError()+" I was unable to create the playlist: "+e.getLocalizedMessage());
+                    event.replyError("I was unable to create the playlist: "+e.getLocalizedMessage());
                 }
             }
             else
-                event.reply(event.getClient().getError()+" Playlist `"+pname+"` already exists!");
+                event.replyError("Playlist `"+pname+"` already exists!");
         }
     }
     
@@ -105,17 +105,17 @@ public class PlaylistCmd extends OwnerCommand
         {
             String pname = event.getArgs().replaceAll("\\s+", "_");
             if(bot.getPlaylistLoader().getPlaylist(pname)==null)
-                event.reply(event.getClient().getError()+" Playlist `"+pname+"` doesn't exist!");
+                event.replyError("Playlist `"+pname+"` doesn't exist!");
             else
             {
                 try
                 {
                     bot.getPlaylistLoader().deletePlaylist(pname);
-                    event.reply(event.getClient().getSuccess()+" Successfully deleted playlist `"+pname+"`!");
+                    event.replySuccess("Successfully deleted playlist `"+pname+"`!");
                 }
                 catch(IOException e)
                 {
-                    event.reply(event.getClient().getError()+" I was unable to delete the playlist: "+e.getLocalizedMessage());
+                    event.replyError("I was unable to delete the playlist: "+e.getLocalizedMessage());
                 }
             }
         }
@@ -138,13 +138,13 @@ public class PlaylistCmd extends OwnerCommand
             String[] parts = event.getArgs().split("\\s+", 2);
             if(parts.length<2)
             {
-                event.reply(event.getClient().getError()+" Please include a playlist name and URLs to add!");
+                event.replyError("Please include a playlist name and URLs to add!");
                 return;
             }
             String pname = parts[0];
             Playlist playlist = bot.getPlaylistLoader().getPlaylist(pname);
             if(playlist==null)
-                event.reply(event.getClient().getError()+" Playlist `"+pname+"` doesn't exist!");
+                event.replyError("Playlist `"+pname+"` doesn't exist!");
             else
             {
                 StringBuilder builder = new StringBuilder();
@@ -160,11 +160,11 @@ public class PlaylistCmd extends OwnerCommand
                 try
                 {
                     bot.getPlaylistLoader().writePlaylist(pname, builder.toString());
-                    event.reply(event.getClient().getSuccess()+" Successfully added "+urls.length+" items to playlist `"+pname+"`!");
+                    event.replySuccess("Successfully added "+urls.length+" items to playlist `"+pname+"`!");
                 }
                 catch(IOException e)
                 {
-                    event.reply(event.getClient().getError()+" I was unable to append to the playlist: "+e.getLocalizedMessage());
+                    event.replyError("I was unable to append to the playlist: "+e.getLocalizedMessage());
                 }
             }
         }
@@ -199,14 +199,14 @@ public class PlaylistCmd extends OwnerCommand
                 bot.getPlaylistLoader().createFolder();
             if(!bot.getPlaylistLoader().folderExists())
             {
-                event.reply(event.getClient().getWarning()+" Playlists folder does not exist and could not be created!");
+                event.replyWarning("Playlists folder does not exist and could not be created!");
                 return;
             }
             List<String> list = bot.getPlaylistLoader().getPlaylistNames();
             if(list==null)
-                event.reply(event.getClient().getError()+" Failed to load available playlists!");
+                event.replyError("Failed to load available playlists!");
             else if(list.isEmpty())
-                event.reply(event.getClient().getWarning()+" There are no playlists in the Playlists folder!");
+                event.replyWarning("There are no playlists in the Playlists folder!");
             else
             {
                 StringBuilder builder = new StringBuilder(event.getClient().getSuccess()+" Available playlists:\n");

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetavatarCmd.java
@@ -52,16 +52,16 @@ public class SetavatarCmd extends OwnerCommand
         InputStream s = OtherUtil.imageFromUrl(url);
         if(s==null)
         {
-            event.reply(event.getClient().getError()+" Invalid or missing URL");
+            event.replyError("Invalid or missing URL");
         }
         else
         {
             try {
             event.getSelfUser().getManager().setAvatar(Icon.from(s)).queue(
-                    v -> event.reply(event.getClient().getSuccess()+" Successfully changed avatar."), 
-                    t -> event.reply(event.getClient().getError()+" Failed to set avatar."));
+                    v -> event.replySuccess("Successfully changed avatar."), 
+                    t -> event.replyError("Failed to set avatar."));
             } catch(IOException e) {
-                event.reply(event.getClient().getError()+" Could not load from provided URL.");
+                event.replyError("Could not load from provided URL.");
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetgameCmd.java
@@ -47,12 +47,12 @@ public class SetgameCmd extends OwnerCommand
         try
         {
             event.getJDA().getPresence().setActivity(title.isEmpty() ? null : Activity.playing(title));
-            event.reply(event.getClient().getSuccess()+" **"+event.getSelfUser().getName()
+            event.replySuccess("**"+event.getSelfUser().getName()
                     +"** is "+(title.isEmpty() ? "no longer playing anything." : "now playing `"+title+"`"));
         }
         catch(Exception e)
         {
-            event.reply(event.getClient().getError()+" The game could not be set!");
+            event.replyError("The game could not be set!");
         }
     }
     
@@ -84,7 +84,7 @@ public class SetgameCmd extends OwnerCommand
             }
             catch(Exception e)
             {
-                event.reply(event.getClient().getError()+" The game could not be set!");
+                event.replyError("The game could not be set!");
             }
         }
     }
@@ -114,7 +114,7 @@ public class SetgameCmd extends OwnerCommand
                 event.getJDA().getPresence().setActivity(Activity.listening(title));
                 event.replySuccess("**"+event.getSelfUser().getName()+"** is now listening to `"+title+"`");
             } catch(Exception e) {
-                event.reply(event.getClient().getError()+" The game could not be set!");
+                event.replyError("The game could not be set!");
             }
         }
     }
@@ -144,7 +144,7 @@ public class SetgameCmd extends OwnerCommand
                 event.getJDA().getPresence().setActivity(Activity.watching(title));
                 event.replySuccess("**"+event.getSelfUser().getName()+"** is now watching `"+title+"`");
             } catch(Exception e) {
-                event.reply(event.getClient().getError()+" The game could not be set!");
+                event.replyError("The game could not be set!");
             }
         }
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetnameCmd.java
@@ -42,15 +42,15 @@ public class SetnameCmd extends OwnerCommand
         {
             String oldname = event.getSelfUser().getName();
             event.getSelfUser().getManager().setName(event.getArgs()).complete(false);
-            event.reply(event.getClient().getSuccess()+" Name changed from `"+oldname+"` to `"+event.getArgs()+"`");
+            event.replySuccess("Name changed from `"+oldname+"` to `"+event.getArgs()+"`");
         } 
         catch(RateLimitedException e) 
         {
-            event.reply(event.getClient().getError()+" Name can only be changed twice per hour!");
+            event.replyError("Name can only be changed twice per hour!");
         }
         catch(Exception e) 
         {
-            event.reply(event.getClient().getError()+" That name is not valid!");
+            event.replyError("That name is not valid!");
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetstatusCmd.java
@@ -50,7 +50,7 @@ public class SetstatusCmd extends OwnerCommand
                 event.replySuccess("Set the status to `"+status.getKey().toUpperCase()+"`");
             }
         } catch(Exception e) {
-            event.reply(event.getClient().getError()+" The status could not be set!");
+            event.replyError("The status could not be set!");
         }
     }
 }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [x] Boosts code quality or performance

### Description
When a `set.*` command is made without an arugment, the current value is printed. I have also bundled in this PR universal usage of convenience methods `replySuccess`, `replyError` , and `replyWarning` to cleanup the code. (I didn't intend to bundle this into one PR, sorry about that)

### Purpose
In some cases, there's no way to get the current config value for a given command, which can be annoying at times. This provides a simple, standardized way to do it.