### PR TITLE
Minor enhancement

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/ForceRemoveCmd.java
@@ -113,7 +113,7 @@ public class ForceRemoveCmd extends DJCommand
         }
         else
         {
-            event.replySuccess("Successfully removed `"+count+"` entries from **"+target.getName()+"**#"+target.getDiscriminator()+".");
+            event.replySuccess("Successfully removed `"+count+(count==1 ? "` entry from **" : "` entries from **")+target.getName()+"**#"+target.getDiscriminator()+".");
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -54,6 +54,7 @@ public class SettingsCmd extends Command
         TextChannel tchan = s.getTextChannel(event.getGuild());
         VoiceChannel vchan = s.getVoiceChannel(event.getGuild());
         Role role = s.getRole(event.getGuild());
+        long connections = event.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inVoiceChannel()).count();
         EmbedBuilder ebuilder = new EmbedBuilder()
                 .setColor(event.getSelfMember().getColor())
                 .setDescription("Text Channel: " + (tchan == null ? "Any" : "**#" + tchan.getName() + "**")
@@ -65,9 +66,7 @@ public class SettingsCmd extends Command
                                                 : "**"+s.getRepeatMode().getUserFriendlyName()+"**")
                         + "\nDefault Playlist: " + (s.getDefaultPlaylist() == null ? "None" : "**" + s.getDefaultPlaylist() + "**")
                         )
-                .setFooter(event.getJDA().getGuilds().size() + " servers | "
-                        + event.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inVoiceChannel()).count()
-                        + " audio connections", null);
+                .setFooter(event.getJDA().getGuilds().size() + " servers | " + connections + " audio " + (connections==1 ? "connection" : "connections"), null);
         event.getChannel().sendMessage(builder.setEmbed(ebuilder.build()).build()).queue();
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -235,13 +235,13 @@ public class PlayCmd extends MusicCommand
                 event.replyError("I could not find `"+event.getArgs()+".txt` in the Playlists folder.");
                 return;
             }
-            event.getChannel().sendMessage(loadingEmoji+" Loading playlist **"+event.getArgs()+"**... ("+playlist.getItems().size()+" items)").queue(m -> 
+            event.getChannel().sendMessage(loadingEmoji+" Loading playlist **"+event.getArgs()+"**... ("+playlist.getItems().size()+(playlist.getItems().size()==1 ? " item)" : " items)")).queue(m -> 
             {
                 AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
                 playlist.loadTracks(bot.getPlayerManager(), (at)->handler.addTrack(new QueuedTrack(at, event.getAuthor())), () -> {
                     StringBuilder builder = new StringBuilder(playlist.getTracks().isEmpty() 
                             ? event.getClient().getWarning()+" No tracks were loaded!" 
-                            : event.getClient().getSuccess()+" Loaded **"+playlist.getTracks().size()+"** tracks!");
+                            : event.getClient().getSuccess()+" Loaded **"+playlist.getTracks().size()+(playlist.getTracks().size()==1 ? "** track!" : "** tracks!"));
                     if(!playlist.getErrors().isEmpty())
                         builder.append("\nThe following tracks failed to load:");
                     playlist.getErrors().forEach(err -> builder.append("\n`[").append(err.getIndex()+1).append("]` **").append(err.getItem()).append("**: ").append(err.getReason()));

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -112,7 +112,7 @@ public class QueueCmd extends MusicCommand
                     .append(ah.getPlayer().getPlayingTrack().getInfo().title).append("**\n");
         }
         return FormatUtil.filter(sb.append(success).append(" Current Queue | ").append(songslength)
-                .append(" entries | `").append(FormatUtil.formatTime(total)).append("` ")
+                .append(songslength==1 ? " entry | `" : " entries | `").append(FormatUtil.formatTime(total)).append("` ")
                 .append(repeatmode.getEmoji() != null ? "| "+repeatmode.getEmoji() : "").toString());
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/RemoveCmd.java
@@ -56,7 +56,7 @@ public class RemoveCmd extends MusicCommand
             if(count==0)
                 event.replyWarning("You don't have any songs in the queue!");
             else
-                event.replySuccess("Successfully removed your "+count+" entries.");
+                event.replySuccess("Successfully removed your "+count+(count==1 ? " entry." : " entries."));
             return;
         }
         int pos;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -160,7 +160,7 @@ public class PlaylistCmd extends OwnerCommand
                 try
                 {
                     bot.getPlaylistLoader().writePlaylist(pname, builder.toString());
-                    event.reply(event.getClient().getSuccess()+" Successfully added "+urls.length+" items to playlist `"+pname+"`!");
+                    event.reply(event.getClient().getSuccess()+" Successfully added "+urls.length+(urls.length==1 ? " item" : " items")+" to playlist `"+pname+"`!");
                 }
                 catch(IOException e)
                 {


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
In this PR I have made very minor changes, improving the overall grammar of the bot's responses.
Here are a few examples, version 0.3.6 being on top and this PR's below.

`1 entries` → `1 entry`
![image](https://user-images.githubusercontent.com/64579257/143508750-065c56db-b273-4c40-8ae0-a503ed7c893a.png)
![image](https://user-images.githubusercontent.com/64579257/143508729-64c52274-a831-4740-8c26-752509ac9f83.png)

`1 items` → `1 item`
![image](https://user-images.githubusercontent.com/64579257/143508814-a880d604-df7e-4ab3-94a3-3249e69b2d43.png)

`1 entries` → `1 entry`
![image](https://user-images.githubusercontent.com/64579257/143508899-05fa8317-16ef-4a00-8020-ded38556875b.png)
![image](https://user-images.githubusercontent.com/64579257/143508882-8932bb32-e885-49d1-b29b-2cd813c05f60.png)

### Purpose
Saying `1 entry` instead of `1 entries` just makes more sense. (grammar duh)
This seemed like a small thing I thought I would be able to fix.
