### PR TITLE
[Issue 751] Add back command 

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -102,6 +102,7 @@ public class JMusicBot
                         new LyricsCmd(bot),
                         new NowplayingCmd(bot),
                         new PlayCmd(bot),
+                        new BackCmd(bot),
                         new PlaylistsCmd(bot),
                         new QueueCmd(bot),
                         new RemoveCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -170,6 +170,13 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
     }
     
     // Audio Events
+    /**
+     * Perform tasks on track end
+     * 
+     * @param player the audio player
+     * @param track the track ending
+     * @param endReason the reason the track is ending
+     */
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) 
     {

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -151,6 +151,23 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
         });
         return true;
     }
+
+    /** 
+     * Play or put in the back of queue the previously-played track
+     * 
+     * @return the previously-played track
+     */
+    public AudioTrack backTrack()
+    {
+        if(audioPlayer.getPlayingTrack()==null)
+        {
+            audioPlayer.playTrack(queue.getPreviousTrack().getTrack());
+        }
+        else {
+            queue.add(queue.getPreviousTrack());
+        }
+        return queue.getPreviousTrack().getTrack();
+    }
     
     // Audio Events
     @Override
@@ -184,6 +201,10 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
             QueuedTrack qt = queue.pull();
             player.playTrack(qt.getTrack());
         }
+
+        // add ended track to queue's previousTrack field (used for back command)
+        QueuedTrack previousTrack = new QueuedTrack(track.makeClone(), track.getUserData(RequestMetadata.class));
+        queue.setPreviousTrack(previousTrack);
     }
 
     @Override

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/BackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/BackCmd.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands.music;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.menu.ButtonMenu;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.audio.AudioHandler;
+import com.jagrosh.jmusicbot.audio.QueuedTrack;
+import com.jagrosh.jmusicbot.commands.DJCommand;
+import com.jagrosh.jmusicbot.commands.MusicCommand;
+import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
+import com.jagrosh.jmusicbot.utils.FormatUtil;
+import java.util.concurrent.TimeUnit;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.exceptions.PermissionException;
+
+/**
+ *
+ * @author John Grosh <john.a.grosh@gmail.com>
+ */
+public class BackCmd extends MusicCommand
+{
+    private final static String LOAD = "\uD83D\uDCE5"; // 📥
+    private final static String CANCEL = "\uD83D\uDEAB"; // 🚫
+    
+    private final String loadingEmoji;
+    
+    public BackCmd(Bot bot)
+    {
+        super(bot);
+        this.loadingEmoji = bot.getConfig().getLoading();
+        this.name = "back";
+        this.help = "plays previous song or adds it to the back of queue";
+        this.aliases = bot.getConfig().getAliases(this.name);
+        this.beListening = true;
+        this.bePlaying = false;
+    }
+
+    @Override
+    public void doCommand(CommandEvent event) 
+    {
+        event.reply(loadingEmoji+" Loading... ", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), "", new ResultHandler(m,event, false)));
+    }
+
+    private class ResultHandler implements AudioLoadResultHandler
+    {
+        private final Message m;
+        private final CommandEvent event;
+        private final boolean ytsearch;
+        
+        private ResultHandler(Message m, CommandEvent event, boolean ytsearch)
+        {
+            this.m = m;
+            this.event = event;
+            this.ytsearch = ytsearch;
+        }
+        
+        private void loadSingle()
+        {
+            AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
+            AudioTrack previousTrack = handler.backTrack();
+            String addMsg = FormatUtil.filter(event.getClient().getSuccess()+" Added **"+previousTrack.getInfo().title
+                    +"** (`"+FormatUtil.formatTime(previousTrack.getDuration())+"`) "+" back to the end of the queue");
+            m.editMessage(addMsg).queue();
+        }
+
+        @Override
+        public void trackLoaded(AudioTrack track)
+        {
+            loadSingle();
+        }
+
+        @Override
+        public void playlistLoaded(AudioPlaylist playlist)
+        {
+            loadSingle();
+        }
+
+        @Override
+        public void noMatches()
+        {
+            loadSingle();
+        }
+
+        @Override
+        public void loadFailed(FriendlyException throwable)
+        {
+            if(throwable.severity==FriendlyException.Severity.COMMON)
+                m.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
+            else
+                m.editMessage(event.getClient().getError()+" Error loading track.").queue();
+        }
+    }
+
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/BackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/BackCmd.java
@@ -17,36 +17,32 @@ package com.jagrosh.jmusicbot.commands.music;
 
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
-import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jdautilities.menu.ButtonMenu;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
-import com.jagrosh.jmusicbot.audio.QueuedTrack;
-import com.jagrosh.jmusicbot.commands.DJCommand;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
-import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
-import java.util.concurrent.TimeUnit;
-import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.exceptions.PermissionException;
 
 /**
  *
  * @author John Grosh <john.a.grosh@gmail.com>
  */
 public class BackCmd extends MusicCommand
-{
-    private final static String LOAD = "\uD83D\uDCE5"; // 📥
-    private final static String CANCEL = "\uD83D\uDEAB"; // 🚫
-    
+{   
+	/**
+	 * Loading emoji
+	 */
     private final String loadingEmoji;
     
-    public BackCmd(Bot bot)
+	/**
+	 * Constructor for back command
+	 * 
+	 * @param bot input bot
+	 */
+    public BackCmd(final Bot bot)
     {
         super(bot);
         this.loadingEmoji = bot.getConfig().getLoading();
@@ -57,59 +53,106 @@ public class BackCmd extends MusicCommand
         this.bePlaying = false;
     }
 
+    /**
+     * Perform the back command
+     * 
+     * @param event Command event
+     */
     @Override
-    public void doCommand(CommandEvent event) 
+    public void doCommand(final CommandEvent event) 
     {
         event.reply(loadingEmoji+" Loading... ", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), "", new ResultHandler(m,event, false)));
     }
 
+    /**
+    * Handles results
+    */
     private class ResultHandler implements AudioLoadResultHandler
     {
-        private final Message m;
+    	/**
+    	 * Message to be replied
+    	 */
+        private final Message message;
+        /**
+         * Event being handled
+         */
         private final CommandEvent event;
+        /**
+         * Youtube search
+         */
         private final boolean ytsearch;
         
-        private ResultHandler(Message m, CommandEvent event, boolean ytsearch)
+        /**
+         * Constructor for result handler
+         * 
+         * @param message Message
+         * @param event Event
+         * @param ytsearch Youtube search
+         */
+        private ResultHandler(final Message message, final CommandEvent event, final boolean ytsearch)
         {
-            this.m = m;
+            this.message = message;
             this.event = event;
             this.ytsearch = ytsearch;
         }
         
+        /**
+         * Load previous track
+         */
         private void loadSingle()
         {
-            AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
-            AudioTrack previousTrack = handler.backTrack();
-            String addMsg = FormatUtil.filter(event.getClient().getSuccess()+" Added **"+previousTrack.getInfo().title
+            final AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
+            final AudioTrack previousTrack = handler.backTrack();
+            final String addMsg = FormatUtil.filter(event.getClient().getSuccess()+" Added **"+previousTrack.getInfo().title
                     +"** (`"+FormatUtil.formatTime(previousTrack.getDuration())+"`) "+" back to the end of the queue");
-            m.editMessage(addMsg).queue();
+            message.editMessage(addMsg).queue();
         }
 
+        /**
+         * Track loaded
+         * 
+         * @param track
+         */
         @Override
-        public void trackLoaded(AudioTrack track)
+        public void trackLoaded(final AudioTrack track)
         {
             loadSingle();
         }
 
+        /**
+         * Playlist loaded
+         * 
+         * @param playlist
+         */
         @Override
-        public void playlistLoaded(AudioPlaylist playlist)
+        public void playlistLoaded(final AudioPlaylist playlist)
         {
             loadSingle();
         }
 
+        /**
+         * No match but still load previous track
+         */
         @Override
         public void noMatches()
         {
             loadSingle();
         }
 
+        /**
+         * Load failed
+         * 
+         * @param throwable
+         */
         @Override
-        public void loadFailed(FriendlyException throwable)
+        public void loadFailed(final FriendlyException throwable)
         {
-            if(throwable.severity==FriendlyException.Severity.COMMON)
-                m.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
-            else
-                m.editMessage(event.getClient().getError()+" Error loading track.").queue();
+            if(throwable.severity==FriendlyException.Severity.COMMON) {
+                message.editMessage(event.getClient().getError()+" Error loading: "+throwable.getMessage()).queue();
+            }
+            else {
+                message.editMessage(event.getClient().getError()+" Error loading track.").queue();
+            }
         }
     }
 

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -21,6 +21,8 @@ import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.RequestMetadata;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.api.entities.User;
+import com.jagrosh.jmusicbot.queue.FairQueue;
+import com.jagrosh.jmusicbot.audio.QueuedTrack;
 
 /**
  *
@@ -69,6 +71,7 @@ public class SkipCmd extends MusicCommand
                 msg += "\n" + event.getClient().getSuccess() + " Skipped **" + handler.getPlayer().getPlayingTrack().getInfo().title
                     + "** " + (rm.getOwner() == 0L ? "(autoplay)" : "(requested by **" + rm.user.username + "**)");
                 handler.getPlayer().stopTrack();
+                handler.getQueue().setPreviousTrack(new QueuedTrack(handler.getPlayer().getPlayingTrack().makeClone(), handler.getPlayer().getPlayingTrack().getUserData(RequestMetadata.class)));
             }
             event.reply(msg);
         }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -39,7 +39,12 @@ public class SkipCmd extends MusicCommand
         this.beListening = true;
         this.bePlaying = true;
     }
-
+    
+    /**
+     * Perform the skip command
+     * 
+     * @param event Command event
+     */
     @Override
     public void doCommand(CommandEvent event) 
     {

--- a/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public class FairQueue<T extends Queueable> {
     private final List<T> list = new ArrayList<>();
     private final Set<Long> set = new HashSet<>();
+    private T previousTrack;
     
     public int add(T item)
     {
@@ -140,5 +141,23 @@ public class FairQueue<T extends Queueable> {
         T item = list.remove(from);
         list.add(to, item);
         return item;
+    }
+
+    /** 
+     * Getter for the previously-played track
+     * 
+     * @return the previously-played track
+     */
+    public T getPreviousTrack() {
+        return this.previousTrack;
+    }
+ 
+    /** 
+     * Setter for the previously-played track
+     * 
+     * @param previousTrack the previously-played track
+     */
+    public void setPreviousTrack(T previousTrack) {
+        this.previousTrack = previousTrack;
     }
 }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds a new command that adds the previously played song to the back of the queue. The command format is as follows (assuming prefix '!'): ```!back```
This PR currently only adds a back command, not a backnext or backforce.
This feature works both for a song that ended and for a song that was skipped with the skip command.

### Purpose
The purpose of this new feature is to give users the ability to go back a song. While the back command puts the previous song to the end of the queue, other commands like backnext or backforce could be added to put the song to the front of the queue or start it immediately.

### Relevant Issue(s)
This PR closes issue #751 
