### PR TITLE
Added skipsegment command that interacts with SponsorBlock API to skip non music segments on YouTube music videos

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -99,7 +99,7 @@ public class JMusicBot
                         new PingCommand(),
                         new SettingsCmd(bot),
                         
-                        new LyricsCmd(bot),
+                        // new LyricsCmd(bot),
                         new NowplayingCmd(bot),
                         new PlayCmd(bot),
                         new PlaylistsCmd(bot),
@@ -109,6 +109,7 @@ public class JMusicBot
                         new SCSearchCmd(bot),
                         new ShuffleCmd(bot),
                         new SkipCmd(bot),
+                        new skipSegCmd(bot),
 
                         new ForceRemoveCmd(bot),
                         new ForceskipCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/skipSegCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/skipSegCmd.java
@@ -1,0 +1,177 @@
+package com.jagrosh.jmusicbot.commands.music;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.audio.AudioHandler;
+import com.jagrosh.jmusicbot.commands.MusicCommand;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import net.dv8tion.jda.api.Permission;
+// import net.dv8tion.jda.api.entities.Message;
+
+public class skipSegCmd extends MusicCommand {
+    public skipSegCmd(Bot bot) {
+
+        super(bot);
+        this.name = "skipsegment";
+        this.help = "Skips to the end of the current non-music segment if it is logged in the SponsorBlock database";
+        this.aliases = bot.getConfig().getAliases(this.name);
+        this.botPermissions = new Permission[] { Permission.MESSAGE_EMBED_LINKS };
+    }
+
+    /**
+     * compares given track URL to a regex to extract the unique video id code at
+     * the end of the URL.
+     * Needed for feeding into sponsorblock API
+     * 
+     * @param youtubeVideoURL video URL string
+     * @return String of video ID code
+     */
+
+    private String extractYTIDRegex(String youtubeVideoURL) {
+        String pattern = "(?<=youtu.be/|watch\\?v=|/videos/|embed\\/)[^#\\&\\?]*";
+        Pattern compiledPattern = Pattern.compile(pattern);
+        Matcher matcher = compiledPattern.matcher(youtubeVideoURL);
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            return "fail"; //probably not a youtube video
+        }
+    }
+
+    /**
+     * Gets the current time stamp of the song in milliseconds
+     * 
+     * @param handler audio handler object to extract the current time
+     * @return returns time in milliseconds
+     */
+    private long getCurrentTimeStamp(AudioHandler handler) {
+        return handler.getPlayer().getPlayingTrack().getPosition();
+    }
+
+    /**
+     * Takes string response from api, and parses the JSON to extract any skippable
+     * segments. Compares start and end of segment to current time.
+     * If current time is within the bounds of a segment, return the time stamp of
+     * the end of that segment so it canbee skipped to.
+     * 
+     * @param jsonString Raw string of API response
+     * @param curTime    current time of track
+     * @return returns end of current skippable segment in milliseconds. If no
+     *         segment is currently playing, return -1
+     */
+
+    private long parseMusicJSON(String jsonString, long curTime) {
+        JSONObject obj = new JSONObject(jsonString);
+        JSONArray segmentArr = obj.getJSONArray("segments");
+        for (int i = 0; i < segmentArr.length(); i++) {
+            Float segStart = segmentArr.getJSONObject(i).getFloat("startTime");
+            Float segEnd = segmentArr.getJSONObject(i).getFloat("endTime");
+            if (curTime >= segStart && curTime <= segEnd) {
+                return (long) (segEnd * 1000);
+            }
+        }
+        return -1; //no skippable segment currently playing
+
+    }
+
+    /**
+     * connect to sponsorblock api and attempt to make a GET call to the
+     * searchSegments option. Attempts to get the end of whatever segment
+     * the player is currently in so the player can skip ahead.
+     * 
+     * @param videoID string of the video id for the song that is currently playing
+     *                off youtube
+     * @param handler audio handler to get current time
+     * @param event   message event to send error responses
+     * @return either returns the end of the current segment in milliseconds, -2 if
+     *         no segments were found, or -1 if segments were found but
+     *         the track is not currently within a segment.
+     * @throws UnsupportedEncodingException
+     * @throws IOException
+     */
+    public long connectToAPI(String videoID, AudioHandler handler, CommandEvent event)
+            throws UnsupportedEncodingException, IOException {
+        HttpURLConnection con = null;
+        long curTime = getCurrentTimeStamp(handler) / 1000; // convert to seconds
+        boolean musicSegment = false;
+
+        try {
+            String nonMusicURLString = "https://sponsor.ajay.app/api/searchSegments?videoID=";
+            nonMusicURLString += videoID;
+            URL nonMusicURL = new URL(nonMusicURLString);
+            String apiResponse = null;
+            try {
+                con = (HttpURLConnection) nonMusicURL.openConnection();
+                con.setRequestMethod("GET");
+                int responsecode = con.getResponseCode();
+                if (responsecode == 200) {
+                    event.replySuccess("Found non-music segments in database!");
+                    musicSegment = true;
+                    BufferedReader in = new BufferedReader(new InputStreamReader(
+                            con.getInputStream()));
+                    while ((apiResponse = in.readLine()) != null) {
+                        return parseMusicJSON(apiResponse, curTime);
+                    }
+
+                    in.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+
+        // no segments found
+        if (!musicSegment) {
+            return -2;
+
+        // segments found but player is not in one currently
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public void doCommand(CommandEvent event) {
+        AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
+        try {
+            String videoId = extractYTIDRegex(handler.getPlayer().getPlayingTrack().getInfo().uri);
+            if (videoId != "fail") {
+                long reply = connectToAPI(videoId, handler, event);
+
+                if (reply == -2) {
+                    event.replyError("No segments found!");
+                } else if (reply == -1) {
+                    event.replyError("Cannot skip here because no segment is currently playing!");
+                } else {
+                    handler.getPlayer().getPlayingTrack().setPosition(reply);
+                    
+                    long absSeconds = reply / 1000;
+                    long minutes = absSeconds / 60;
+                    long modSeconds = absSeconds % 60;
+                    String formattedSeconds = String.format("%02d", modSeconds);
+                    String msg = "Skipping ahead to " + minutes + ":" + formattedSeconds + "!";
+                    event.replySuccess(msg);
+                }
+            } else {
+                event.replyError("Could not get video ID!"); //should only come up on non-youtube links
+            }
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+}


### PR DESCRIPTION

### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This implements feature request #982 and adds a new command that allows a user to optionally skip the non-music segment that is currently playing. This feature is implemented with the skipSegCmd class which retrieves the URL of the currently playing song, extracts the video ID, sends a request to the SponsorBlock API, and parses the JSON file. The JSON parser returns either an error code (-1) or the millisecond value of the end of the current segment if one is found. If it succeeded, it will tell the user where the track is seeking to. If it failed it will tell the user why. It uses the lava player setPosition() method to set the track position to the correct time upon success.

### Purpose
When listening to a music video on YouTube, there are often non-music sections or intros that are impossible to skip, and can be very frustrating to sit through without visual context. This often makes these versions of songs unplayable. This feature is invoked with the "skipsegment" command. The user will use this command while a song is playing to skip to the end of the current segment in a song. The command will return the timestamp for the segment that it is jumping ahead to or display “No segments found”. If the song is in the last segment of the song and the user tries to skipSegment, the message “Cannot skip here because no segment is currently playing!”.  This happens since there are no segments left in the song. This feature only works with YouTube videos, due to the limitations of the SponsorBlock API, so if the user tries to skipSegment while playing a SoundCloud, Vimeo, or Twitch stream, they will get a “Could not get video ID!” message. 

Command succeeding by skipping a segment that is currently playing and moving the track ahead to the correct location:
![Screen Shot 2021-12-05 at 8 36 49 PM](https://user-images.githubusercontent.com/61125205/144774876-ed64dd42-85bb-484e-ba7c-bf87172b82ad.png)

Command succeeding at retrieving database entry but failing because no non-music segment is currently playing:
![Screen Shot 2021-12-05 at 8 36 59 PM](https://user-images.githubusercontent.com/61125205/144774942-355d0e18-7457-4c4b-a540-040a0600d8e7.png)


Command failing because the song is not in the SponsorBlock database:
![Screen Shot 2021-12-05 at 8 37 10 PM](https://user-images.githubusercontent.com/61125205/144774784-7c5d7214-13fc-4200-8532-0bcad5aed75f.png)



### Relevant Issue(s)
This PR closes feature request #982 