### PR TITLE
inplement mod, s3m and xm support via lavaplayer's xm-format extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,23 @@
             <version>4.3.0_324</version>
         </dependency>
         <!-- using a fork of this to fix some issues faster -->
-        <!-- dependency>
-            <groupId>com.sedmelluq</groupId>
-            <artifactId>lavaplayer</artifactId>
-            <version>1.3.78</version>
-        </dependency -->
+<!--        <dependency>-->
+<!--            <groupId>com.sedmelluq</groupId>-->
+<!--            <artifactId>lavaplayer</artifactId>-->
+<!--            <version>1.3.78</version>-->
+<!--        </dependency>-->
+        <!--  use fork of format-xm until it gets merged into lavaplayer -->
         <dependency>
-	    <groupId>com.github.jagrosh</groupId>
-	    <artifactId>lavaplayer</artifactId>
-	    <version>jmusicbot-SNAPSHOT</version>
-	</dependency>
+            <groupId>com.github.forkiesassds.lavaplayer</groupId>
+            <artifactId>lavaplayer-ext-format-xm</artifactId>
+            <version>master-SNAPSHOT</version>
+            <classifier>uber</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jagrosh</groupId>
+            <artifactId>lavaplayer</artifactId>
+            <version>jmusicbot-SNAPSHOT</version>
+	    </dependency>
         <!-- this is needed, but isn't actually hosted anywhere anymore... uh -->
         <!--dependency>
             <groupId>com.sedmelluq</groupId>

--- a/src/main/java/com/jagrosh/jmusicbot/audio/MediaContainers.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/MediaContainers.java
@@ -1,0 +1,60 @@
+package com.jagrosh.jmusicbot.audio;
+
+import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.adts.AdtsContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.flac.FlacContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.matroska.MatroskaContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.mp3.Mp3ContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.mpegts.MpegAdtsContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.ogg.OggContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.playlists.M3uPlaylistContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.playlists.PlainPlaylistContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.playlists.PlsPlaylistContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.wav.WavContainerProbe;
+import com.sedmelluq.lavaplayer.extensions.format.xm.ModContainerProbe;
+import com.sedmelluq.lavaplayer.extensions.format.xm.S3MContainerProbe;
+import com.sedmelluq.lavaplayer.extensions.format.xm.XmContainerProbe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum MediaContainers {
+    WAV(new WavContainerProbe()),
+    MKV(new MatroskaContainerProbe()),
+    MP4(new MpegContainerProbe()),
+    FLAC(new FlacContainerProbe()),
+    OGG(new OggContainerProbe()),
+    M3U(new M3uPlaylistContainerProbe()),
+    PLS(new PlsPlaylistContainerProbe()),
+    PLAIN(new PlainPlaylistContainerProbe()),
+    MP3(new Mp3ContainerProbe()),
+    ADTS(new AdtsContainerProbe()),
+    MPEGADTS(new MpegAdtsContainerProbe()),
+    MOD(new ModContainerProbe()),
+    S3M(new S3MContainerProbe()),
+    XM(new XmContainerProbe());
+
+    /**
+     * The probe used to detect files using this container and create the audio tracks for them.
+     */
+    public final MediaContainerProbe probe;
+
+    MediaContainers(MediaContainerProbe probe) {
+        this.probe = probe;
+    }
+
+    public static List<MediaContainerProbe> asList() {
+        List<MediaContainerProbe> probes = new ArrayList<>();
+
+        for (com.sedmelluq.discord.lavaplayer.container.MediaContainer container : com.sedmelluq.discord.lavaplayer.container.MediaContainer.class.getEnumConstants()) {
+            probes.add(container.probe);
+        }
+        //hack to forcefully add the probes in the xm-format extension
+        probes.add(MOD.probe);
+        probes.add(S3M.probe);
+        probes.add(XM.probe);
+
+        return probes;
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -16,11 +16,11 @@
 package com.jagrosh.jmusicbot.audio;
 
 import com.jagrosh.jmusicbot.Bot;
+import com.sedmelluq.discord.lavaplayer.container.MediaContainerRegistry;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
-import com.typesafe.config.Config;
 import net.dv8tion.jda.api.entities.Guild;
 
 /**
@@ -39,8 +39,9 @@ public class PlayerManager extends DefaultAudioPlayerManager
     public void init()
     {
         TransformativeAudioSourceManager.createTransforms(bot.getConfig().getTransforms()).forEach(t -> registerSourceManager(t));
-        AudioSourceManagers.registerRemoteSources(this);
-        AudioSourceManagers.registerLocalSource(this);
+        AudioSourceManagers.registerRemoteSources(this, new MediaContainerRegistry(MediaContainers.asList()));
+        AudioSourceManagers.registerLocalSource(this, new MediaContainerRegistry(MediaContainers.asList()));
+
         source(YoutubeAudioSourceManager.class).setPlaylistPageCount(10);
     }
     


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This implements Lavaplayer's xm-format extension (via a fork due to upstream having no working builds) to allow people to play mod, s3m and xm files.

### Purpose
This allows people to play a lot of tracker files via the bot.

### Relevant Issue(s)
None.
