### PR TITLE
Allow using the -stop command without a DJ role set

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/DJCommand.java
@@ -43,6 +43,6 @@ public abstract class DJCommand extends MusicCommand
             return true;
         Settings settings = event.getClient().getSettingsFor(event.getGuild());
         Role dj = settings.getRole(event.getGuild());
-        return dj!=null && (event.getMember().getRoles().contains(dj) || dj.getIdLong()==event.getGuild().getIdLong());
+        return dj==null || event.getMember().getRoles().contains(dj) || dj.getIdLong()==event.getGuild().getIdLong();
     }
 }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [X] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
If no DJ role is set, any user can now stop the bot and remove it from the channel. 

### Purpose
This is very useful for well-behaved servers, where admins haven't configured or don't want to configure DJ roles. This prevents someone from accidentally leaving a large music queue running, and leave the voice channel, and regular users have no way of stopping the bot.
