### PR TITLE
Allow configurable default skip ratio

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -44,6 +44,7 @@ public class BotConfig
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
+    private double skipratio;
     private OnlineStatus status;
     private Activity game;
     private Config aliases, transforms;
@@ -98,6 +99,7 @@ public class BotConfig
             playlistsFolder = config.getString("playlistsfolder");
             aliases = config.getConfig("aliases");
             transforms = config.getConfig("transforms");
+            skipratio = config.getDouble("skipratio");
             dbots = owner == 113156185389092864L;
             
             // we may need to write a new config file
@@ -209,6 +211,11 @@ public class BotConfig
     public String getToken()
     {
         return token;
+    }
+    
+    public double getSkipRatio()
+    {
+        return skipratio;
     }
     
     public long getOwnerId()

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -76,7 +76,7 @@ public class JMusicBot
         
         // set up the listener
         EventWaiter waiter = new EventWaiter();
-        SettingsManager settings = new SettingsManager();
+        SettingsManager settings = new SettingsManager(config);
         Bot bot = new Bot(waiter, config, settings);
         
         AboutCommand aboutCommand = new AboutCommand(Color.BLUE.brighter(),

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -76,7 +76,7 @@ public class JMusicBot
         
         // set up the listener
         EventWaiter waiter = new EventWaiter();
-        SettingsManager settings = new SettingsManager(config);
+        SettingsManager settings = new SettingsManager();
         Bot bot = new Bot(waiter, config, settings);
         
         AboutCommand aboutCommand = new AboutCommand(Color.BLUE.brighter(),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -43,7 +43,7 @@ public class SkipCmd extends MusicCommand
     {
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
         RequestMetadata rm = handler.getRequestMetadata();
-        if(event.getAuthor().getIdLong() == rm.getOwner())
+        if(event.getAuthor().getIdLong() == rm.getOwner() || bot.getSettingsManager().getSettings(event.getGuild()).getSkipRatio() <= 0)
         {
             event.reply(event.getClient().getSuccess()+" Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title+"**");
             handler.getPlayer().stopTrack();

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SkipCmd.java
@@ -43,7 +43,11 @@ public class SkipCmd extends MusicCommand
     {
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
         RequestMetadata rm = handler.getRequestMetadata();
-        if(event.getAuthor().getIdLong() == rm.getOwner() || bot.getSettingsManager().getSettings(event.getGuild()).getSkipRatio() <= 0)
+        double skipRatio = bot.getSettingsManager().getSettings(event.getGuild()).getSkipRatio();
+        if(skipRatio == -1) {
+          skipRatio = bot.getConfig().getSkipRatio();
+        }
+        if(event.getAuthor().getIdLong() == rm.getOwner() || skipRatio == 0)
         {
             event.reply(event.getClient().getSuccess()+" Skipped **"+handler.getPlayer().getPlayingTrack().getInfo().title+"**");
             handler.getPlayer().stopTrack();
@@ -62,7 +66,7 @@ public class SkipCmd extends MusicCommand
             }
             int skippers = (int)event.getSelfMember().getVoiceState().getChannel().getMembers().stream()
                     .filter(m -> handler.getVotes().contains(m.getUser().getId())).count();
-            int required = (int)Math.ceil(listeners * bot.getSettingsManager().getSettings(event.getGuild()).getSkipRatio());
+            int required = (int)Math.ceil(listeners * skipRatio);
             msg += skippers + " votes, " + required + "/" + listeners + " needed]`";
             if(skippers>=required)
             {

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -15,6 +15,7 @@
  */
 package com.jagrosh.jmusicbot.settings;
 
+import com.jagrosh.jmusicbot.BotConfig;
 import com.jagrosh.jdautilities.command.GuildSettingsManager;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import java.io.IOException;
@@ -31,12 +32,14 @@ import org.slf4j.LoggerFactory;
  */
 public class SettingsManager implements GuildSettingsManager
 {
-    private final static double SKIP_RATIO = .55;
     private final HashMap<Long,Settings> settings;
+    private final BotConfig config;
 
-    public SettingsManager()
+    public SettingsManager(BotConfig config)
     {
         this.settings = new HashMap<>();
+        this.config = config;
+        
         try {
             JSONObject loadedSettings = new JSONObject(new String(Files.readAllBytes(OtherUtil.getPath("serversettings.json"))));
             loadedSettings.keySet().forEach((id) -> {
@@ -55,7 +58,7 @@ public class SettingsManager implements GuildSettingsManager
                         o.has("default_playlist")? o.getString("default_playlist")           : null,
                         o.has("repeat_mode")     ? o.getEnum(RepeatMode.class, "repeat_mode"): RepeatMode.OFF,
                         o.has("prefix")          ? o.getString("prefix")                     : null,
-                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
+                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : this.config.getSkipRatio()));
             });
         } catch(IOException | JSONException e) {
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
@@ -81,7 +84,7 @@ public class SettingsManager implements GuildSettingsManager
     
     private Settings createDefaultSettings()
     {
-        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, SKIP_RATIO);
+        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, this.config.getSkipRatio());
     }
     
     protected void writeSettings()
@@ -104,7 +107,7 @@ public class SettingsManager implements GuildSettingsManager
                 o.put("repeat_mode", s.getRepeatMode());
             if(s.getPrefix() != null)
                 o.put("prefix", s.getPrefix());
-            if(s.getSkipRatio() != SKIP_RATIO)
+            if(s.getSkipRatio() != this.config.getSkipRatio())
                 o.put("skip_ratio", s.getSkipRatio());
             obj.put(Long.toString(key), o);
         });

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -15,7 +15,6 @@
  */
 package com.jagrosh.jmusicbot.settings;
 
-import com.jagrosh.jmusicbot.BotConfig;
 import com.jagrosh.jdautilities.command.GuildSettingsManager;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import java.io.IOException;
@@ -33,12 +32,10 @@ import org.slf4j.LoggerFactory;
 public class SettingsManager implements GuildSettingsManager
 {
     private final HashMap<Long,Settings> settings;
-    private final BotConfig config;
 
-    public SettingsManager(BotConfig config)
+    public SettingsManager()
     {
         this.settings = new HashMap<>();
-        this.config = config;
         
         try {
             JSONObject loadedSettings = new JSONObject(new String(Files.readAllBytes(OtherUtil.getPath("serversettings.json"))));
@@ -58,7 +55,7 @@ public class SettingsManager implements GuildSettingsManager
                         o.has("default_playlist")? o.getString("default_playlist")           : null,
                         o.has("repeat_mode")     ? o.getEnum(RepeatMode.class, "repeat_mode"): RepeatMode.OFF,
                         o.has("prefix")          ? o.getString("prefix")                     : null,
-                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : this.config.getSkipRatio()));
+                        o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : -1));
             });
         } catch(IOException | JSONException e) {
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
@@ -84,7 +81,7 @@ public class SettingsManager implements GuildSettingsManager
     
     private Settings createDefaultSettings()
     {
-        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, this.config.getSkipRatio());
+        return new Settings(this, 0, 0, 0, 100, null, RepeatMode.OFF, null, -1);
     }
     
     protected void writeSettings()
@@ -107,7 +104,7 @@ public class SettingsManager implements GuildSettingsManager
                 o.put("repeat_mode", s.getRepeatMode());
             if(s.getPrefix() != null)
                 o.put("prefix", s.getPrefix());
-            if(s.getSkipRatio() != this.config.getSkipRatio())
+            if(s.getSkipRatio() != -1)
                 o.put("skip_ratio", s.getSkipRatio());
             obj.put(Long.toString(key), o);
         });

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -99,6 +99,13 @@ stayinchannel = false
 maxtime = 0
 
 
+// This sets the ratio of users that must vote to skip the currently playing song.
+// Guild owners can define their own skip ratios, but this will be used if a guild
+// has not defined their own skip ratio.
+
+skipratio = 0.55
+
+
 // This sets the amount of seconds the bot will stay alone on a voice channel until it
 // automatically leaves the voice channel and clears the queue. If not set or set
 // to any number less than or equal to zero, the bot won't leave when alone.


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [X] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Allows the server owner to configure the skip ratio in config.txt, including disabling vote-related messages if skip ratio is 0

### Purpose
Useful for owners being able to set a default ratio. Setting to "0" and having no vote-related messages is also helpful for well-behaved, or small servers, where music playing is mostly co-operative, and people may want to skip troll songs or livestreams that have gone on too long.
