### PR TITLE
Update generated description in release workflow

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -67,4 +67,4 @@ jobs:
             ### Setup
             https://jmusicbot.com/setup  
             https://jmusicbot.com/config  
-            # Download *only* the `.jar` file below!
+            # Download: [JMusicBot-${{ github.event.inputs.version_number }}.jar](https://github.com/jagrosh/MusicBot/releases/download/${{ github.event.inputs.version_number }}/JMusicBot-${{ github.event.inputs.version_number }}.jar)


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
In the release descriptions, instead of saying:

> #  Download *only* the `.jar` file below!

Provide a direct link to the jar file instead like so:

> # Download: [JMusicBot-0.3.8.jar](https://github.com/jagrosh/MusicBot/releases/download/0.3.8/JMusicBot-0.3.8.jar)

### Purpose
Decreases the chances of people (unintentionally) downloading the source, instead of the jar.

### Relevant Issue(s)
None
