### PR TITLE
Another type of queue

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -40,7 +40,7 @@ public class BotConfig
     
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder,
-            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
+            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji, queueAlgorithm;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private OnlineStatus status;
@@ -92,6 +92,7 @@ public class BotConfig
             aliases = config.getConfig("aliases");
             transforms = config.getConfig("transforms");
             dbots = owner == 113156185389092864L;
+            queueAlgorithm = config.getString("queuealgorithm"); //"fair", "unfair"
             
             // we may need to write a new config file
             boolean write = false;
@@ -348,5 +349,9 @@ public class BotConfig
     public Config getTransforms()
     {
         return transforms;
+    }
+
+    public String getQueueAlgorithm(){
+        return queueAlgorithm;
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -15,8 +15,9 @@
  */
 package com.jagrosh.jmusicbot.audio;
 
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
+import com.jagrosh.jmusicbot.queue.Queue;
+import com.jagrosh.jmusicbot.queue.UnfairQueue;
 import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
@@ -50,7 +51,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
     public final static String PAUSE_EMOJI = "\u23F8"; // ⏸
     public final static String STOP_EMOJI  = "\u23F9"; // ⏹
     
-    private final FairQueue<QueuedTrack> queue = new FairQueue<>();
+    private final Queue<QueuedTrack> queue;
     private final List<AudioTrack> defaultQueue = new LinkedList<>();
     private final Set<String> votes = new HashSet<>();
     
@@ -65,6 +66,9 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
         this.manager = manager;
         this.audioPlayer = player;
         this.guildId = guild.getIdLong();
+
+        this.queue = manager.getBot().getConfig().getQueueAlgorithm()
+                .equalsIgnoreCase("unfair") ? new UnfairQueue<>() : new FairQueue<>();
     }
 
     public int addTrackToFront(QueuedTrack qtrack)
@@ -92,7 +96,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
             return queue.add(qtrack);
     }
     
-    public FairQueue<QueuedTrack> getQueue()
+    public Queue<QueuedTrack> getQueue()
     {
         return queue;
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/MoveTrackCmd.java
@@ -6,7 +6,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.audio.QueuedTrack;
 import com.jagrosh.jmusicbot.commands.DJCommand;
-import com.jagrosh.jmusicbot.queue.FairQueue;
+import com.jagrosh.jmusicbot.queue.Queue;
 
 /**
  * Command that provides users the ability to move a track in the playlist.
@@ -57,7 +57,7 @@ public class MoveTrackCmd extends DJCommand
 
         // Validate that from and to are available
         AudioHandler handler = (AudioHandler) event.getGuild().getAudioManager().getSendingHandler();
-        FairQueue<QueuedTrack> queue = handler.getQueue();
+        Queue<QueuedTrack> queue = handler.getQueue();
         if (isUnavailablePosition(queue, from))
         {
             String reply = String.format("`%d` is not a valid position in the queue!", from);
@@ -78,7 +78,7 @@ public class MoveTrackCmd extends DJCommand
         event.replySuccess(reply);
     }
 
-    private static boolean isUnavailablePosition(FairQueue<QueuedTrack> queue, int position)
+    private static boolean isUnavailablePosition(Queue<QueuedTrack> queue, int position)
     {
         return (position < 1 || position > queue.size());
     }

--- a/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/FairQueue.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * @author John Grosh (jagrosh)
  * @param <T>
  */
-public class FairQueue<T extends Queueable> {
+public class FairQueue<T extends Queueable> implements Queue<T> {
     private final List<T> list = new ArrayList<>();
     private final Set<Long> set = new HashSet<>();
     

--- a/src/main/java/com/jagrosh/jmusicbot/queue/Queue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/Queue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 John Grosh (jagrosh).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.queue;
+
+import java.util.List;
+
+/**
+ * @author SH1n3g4ter
+ * @param <T>
+ */
+public interface Queue<T extends Queueable> {
+    int add(T item);
+    void addAt(int index, T item);
+    int size();
+    T pull();
+    boolean isEmpty();
+    List<T> getList();
+    T get(int index);
+    T remove(int index);
+    int removeAll(long id);
+    void clear();
+    int shuffle(long id);
+    void skip(int number);
+    T moveItem(int from, int to);
+}

--- a/src/main/java/com/jagrosh/jmusicbot/queue/UnfairQueue.java
+++ b/src/main/java/com/jagrosh/jmusicbot/queue/UnfairQueue.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 John Grosh (jagrosh).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.queue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * queue that maintains addition order, no fairness between different users
+ * who adds first gets to play first
+ * @author SH1n3g4ter
+ * @param <T>
+ */
+public class UnfairQueue <T extends Queueable> implements Queue<T> {
+    private final List<T> list = new ArrayList<>();
+
+    public int add(T item) {
+        list.add(item);
+        return list.size()-1;
+    }
+
+    public void addAt(int index, T item) {
+        if (index >= list.size())
+            list.add(item);
+        else
+            list.add(index, item);
+    }
+
+    public int size() {
+        return list.size();
+    }
+
+    public T pull() {
+        return list.remove(0);
+    }
+
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    public List<T> getList() {
+        return list;
+    }
+
+    public T get(int index) {
+        return list.get(index);
+    }
+
+    public T remove(int index) {
+        return list.remove(index);
+    }
+
+    public int removeAll(long identifier) {
+        int listSize = list.size();
+        list.clear();
+        return listSize;
+    }
+
+    public void clear() {
+        list.clear();
+    }
+
+    public int shuffle(long identifier) {
+        Collections.shuffle(list);
+        return list.size();
+    }
+
+    public void skip(int number) {
+        for (int i = 0; i < number; i++)
+            list.remove(0);
+    }
+
+    /**
+     * Move an item to a different position in the list
+     *
+     * @param from The position of the item
+     * @param to   The new position of the item
+     * @return the moved item
+     */
+    public T moveItem(int from, int to) {
+        T item = list.remove(from);
+        list.add(to, item);
+        return item;
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -128,6 +128,9 @@ updatealerts=true
 
 lyrics.default = "A-Z Lyrics"
 
+// Change this to switch between a FairQueue ["fair"] and a queue
+// that keeps insertion order (first come, first served) ["unfair"]
+queuealgorithm = "fair"
 
 // These settings allow you to configure custom aliases for all commands.
 // Multiple aliases may be given, separated by commas.


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This adds another type of queue, instead of the already existing `FairQueue`.
This `UnfairQueue` strictly maintains insertion order.
Songs are just consecutively added to the list independent of who added them.

I also wrote an interface `Queue` to generalize the queue types.

You can change which type to use by setting the **config.txt** option `queuealgorithm` to either `"fair"` or `"unfair"`.
The default queue type remains `FairQueue` and continues to function as usual.

### Purpose
When multiple users add different playlists the songs get mixed up due to the `FairQueue`, which might be wanted or not.
I personally prefer it not to be like that, thats why I added another queue type. 

### Relevant Issue(s)
None
