### PR TITLE
Queue entry formatting fix

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/QueuedTrack.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/QueuedTrack.java
@@ -16,6 +16,7 @@
 package com.jagrosh.jmusicbot.audio;
 
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import com.jagrosh.jmusicbot.queue.Queueable;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.entities.User;
@@ -53,6 +54,9 @@ public class QueuedTrack implements Queueable
     @Override
     public String toString() 
     {
-        return "`[" + FormatUtil.formatTime(track.getDuration()) + "]` [**" + track.getInfo().title + "**]("+track.getInfo().uri+") - <@" + track.getUserData(RequestMetadata.class).getOwner() + ">";
+        String entry = "`[" + FormatUtil.formatTime(track.getDuration()) + "]` ";
+        AudioTrackInfo trackInfo = track.getInfo();
+        entry = entry + (trackInfo.uri.startsWith("http") ? "[**" + trackInfo.title + "**]("+trackInfo.uri+")" : "**" + trackInfo.title + "**");
+        return entry + " - <@" + track.getUserData(RequestMetadata.class).getOwner() + ">";
     }
 }


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR changes the way queue entries are formatted. All URIs that don't start with `http` aren't formatted and shall appear as plain text.

![image](https://user-images.githubusercontent.com/64579257/177857508-ddf1f58c-78f2-4423-bdcd-2837dcca3de4.png)

This is because http URLs only contain alfabetic letters, numbers and a few symbols, and not characters like Han which causes problems with Discord's formatting.
https://developers.google.com/maps/url-encoding

### Purpose
As explained in issue #1191 file names containing Han characters mess up the way Discord handles the queue entry formatting.

![image](https://user-images.githubusercontent.com/64579257/177858279-70a908e7-9e9b-4fc8-945d-eab01e6fe4c1.png) 

### Relevant Issue(s)
This PR closes issue #1191 
