### PR TITLE
Config options to control the !!nowplaying refreshing

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -41,8 +41,8 @@ public class BotConfig
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
-    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
-    private long owner, maxSeconds, aloneTimeUntilStop;
+    private boolean stayInChannel, songInGame, updateNP, npImages, updatealerts, useEval, dbots;
+    private long owner, updateNPTime, maxSeconds, aloneTimeUntilStop;
     private OnlineStatus status;
     private Activity game;
     private Config aliases, transforms;
@@ -83,6 +83,8 @@ public class BotConfig
             status = OtherUtil.parseStatus(config.getString("status"));
             stayInChannel = config.getBoolean("stayinchannel");
             songInGame = config.getBoolean("songinstatus");
+            updateNP = config.getBoolean("updatenp");
+            updateNPTime = config.getLong("updatenptime");
             npImages = config.getBoolean("npimages");
             updatealerts = config.getBoolean("updatealerts");
             useEval = config.getBoolean("eval");
@@ -304,6 +306,16 @@ public class BotConfig
     public boolean useEval()
     {
         return useEval;
+    }
+    
+    public boolean getUpdateNP()
+    {
+        return updateNP;
+    }
+    
+    public long getUpdateNPTime()
+    {
+        return updateNPTime;
     }
     
     public boolean useNPImages()

--- a/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
@@ -48,8 +48,12 @@ public class NowplayingHandler
     
     public void init()
     {
-        if(!bot.getConfig().useNPImages())
-            bot.getThreadpool().scheduleWithFixedDelay(() -> updateAll(), 0, 5, TimeUnit.SECONDS);
+        if(bot.getConfig().getUpdateNP() && !bot.getConfig().useNPImages())
+            bot.getThreadpool().scheduleWithFixedDelay(
+                () -> updateAll(),
+                0,
+                bot.getConfig().getUpdateNPTime(),
+                TimeUnit.SECONDS);
     }
     
     public void setLastNPMessage(Message m)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -77,6 +77,15 @@ searching = "🔎"
 help = help
 
 
+// If you set this, the "nowplaying" command will refresh every n-seconds,
+// specified in option "updatenptime" below.
+updatenp = true
+
+
+// This sets the amount of seconds of "nowplaying" refreshing interval.
+updatenptime = 5
+
+
 // If you set this, the "nowplaying" command will show youtube thumbnails
 // Note: If you set this to true, the nowplaying boxes will NOT refresh
 // This is because refreshing the boxes causes the image to be reloaded


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
PR introduces two new config options: `updatenp` and `updatenptime`. These grants the user an ability to control whether the bot should periodically update the output of `!!np` command, and if so, how often to do it.

### Purpose
Implementing these options solves the issue of exceeding the Discord API rate limits.

### Relevant Issue(s)
This PR closes issue #1254
