### PR TITLE
Add documentation for running JMusicBot as a service

### DIFF
--- a/docs/running-as-a-service.md
+++ b/docs/running-as-a-service.md
@@ -25,7 +25,7 @@ sudo nano /etc/systemd/system/JMusicBot.service
 ```ini
 [Unit]
 Description=JMusicBot
-Wants=network.target
+Requires=network.target
 After=network.target
 
 [Service]

--- a/docs/running-as-a-service.md
+++ b/docs/running-as-a-service.md
@@ -25,6 +25,7 @@ sudo nano /etc/systemd/system/JMusicBot.service
 ```ini
 [Unit]
 Description=JMusicBot
+Wants=network.target
 After=network.target
 
 [Service]
@@ -32,7 +33,7 @@ WorkingDirectory=/home/<username>
 User=<username>
 Group=<username>
 Type=simple
-ExecStart=/usr/bin/java -Dnogui=true -jar /home/<username>/JMusicBot.jar
+ExecStart=/usr/bin/env java -Dnogui=true -jar JMusicBot.jar
 Restart=always
 RestartSec=10
 

--- a/docs/running-as-a-service.md
+++ b/docs/running-as-a-service.md
@@ -1,0 +1,121 @@
+---
+title: Running as a service
+description: "How to run JMusicBot as a service, so that it can run in the background without needing to be manually started."
+---
+
+## Running as a service
+Running JMusicBot as a service allows it to run in the background without needing to be manually started. This is useful for running the bot on a server, or if you want to be able to close your terminal without stopping the bot.
+
+### Linux using systemd
+
+!!! warning
+    This method assumes that you've created a user for the bot to run as. If you haven't, see [this guide](https://www.digitalocean.com/community/tutorials/how-to-create-a-sudo-user-on-ubuntu-quickstart) for instructions.
+
+!!! note
+    Copy the jar file to the home directory of the user that the bot is running as, or change the `WorkingDirectory` and `ExecStart` lines in the service file to point to the correct location.
+
+1. Open a terminal and run the following command to create a new service file:
+
+```bash
+sudo nano /etc/systemd/system/JMusicBot.service
+```
+
+2. Copy the following text into the file and save it:
+
+```ini
+[Unit]
+Description=JMusicBot
+After=network.target
+
+[Service]
+WorkingDirectory=/home/<username>
+User=<username>
+Group=<username>
+Type=simple
+ExecStart=/usr/bin/java -Dnogui=true -jar /home/<username>/JMusicBot.jar
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+!!! note
+    Replace `<username>` with the name of the user that the bot is running as.
+
+4. Run the following command to start the bot:
+
+```bash
+sudo systemctl start JMusicBot
+```
+
+5. Run the following command to stop the bot:
+
+```bash
+sudo systemctl stop JMusicBot
+```
+
+6. Run the following command to restart the bot:
+
+```bash
+sudo systemctl restart JMusicBot
+```
+
+7. Run the following command to enable the bot to start on boot:
+
+```bash
+sudo systemctl enable JMusicBot
+```
+
+
+### Linux using screen
+
+!!! warning
+    This method is not recommended for production use, see [systemd](#linux-using-systemd) instead.
+
+1. Install the [screen](https://www.howtoforge.com/linux_screen) utility, if it isn't already installed.
+2. Run the following command to start the bot:
+
+```bash
+screen -dmS JMusicBot java -jar JMusicBot.jar
+```
+
+3. Run the following command to stop the bot:
+
+```bash
+screen -S JMusicBot -X quit
+```
+
+4. Run the following command to restart the bot:
+
+```bash
+screen -S JMusicBot -X quit
+screen -dmS JMusicBot java -jar JMusicBot.jar
+```
+
+### Windows
+
+1. Download the [NSSM](https://nssm.cc/download) executable and place it in the same directory as the JMusicBot jar file.
+2. Open a command prompt in the same directory as the JMusicBot jar file and run the following command:
+
+```bat
+nssm install JMusicBot java -jar JMusicBot.jar
+```
+
+3. Run the following command to start the service:
+
+```bat
+nssm start JMusicBot
+```
+
+4. Run the following command to stop the service:
+
+```bat
+nssm stop JMusicBot
+```
+
+5. Run the following command to remove the service:
+
+```bat
+nssm remove JMusicBot
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,9 +29,11 @@ prefix = "!"
 * Run the jar file (choose one of these options):
   * Double-click the jar file (on desktop environments), OR
   * Run `java -Dnogui=true -jar JMusicBot-X.Y.Z.jar` from the command line (replace X, Y, and Z with the release numbers), OR
-  * Run `nohup java -Dnogui=true -jar JMusicBot-X.Y.Z.jar &` to run in the background (Linux only)
 * Provide the requested information, if prompted.
 * Wait for the "Finished Loading" message.
+
+!!! tip
+    If you want to run the bot in the background, see [Running as a Service](running-as-a-service.md)
 
 ## 5️⃣ Add your bot to your server
 * When the bot starts, if it hasn't been added to any servers yet, it will provide you with a link in the console.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,7 +28,7 @@ prefix = "!"
 ## 4️⃣ Run JMusicBot
 * Run the jar file (choose one of these options):
   * Double-click the jar file (on desktop environments), OR
-  * Run `java -Dnogui=true -jar JMusicBot-X.Y.Z.jar` from the command line (replace X, Y, and Z with the release numbers), OR
+  * Run `java -Dnogui=true -jar JMusicBot-X.Y.Z.jar` from the command line (replace X, Y, and Z with the release numbers)
 * Provide the requested information, if prompted.
 * Wait for the "Finished Loading" message.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - config.md
     - advanced-config.md
     - hosting.md
+    - running-as-a-service.md
   - Reference:
     - commands.md
     - playlists.md


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [x] Boosts code quality or performance

### Description
Add documentation for running JMusicBot as a service

### Purpose
Currently, the docs frequently mention using `nohup` as a solution for running the bot 'detached' from the current terminal session. Using `nohup` has significant disadvantages, such as losing access to the logs, the process not automatically restarting itself, and not being able to start on system boot.

This PR removes references to `nohup` and introduces documentation for running using `screen` or as a systemd service, it also includes some documentation on using [NSSM](https://nssm.cc) for service management on Windows.

### Relevant Issue(s)
#410 
https://github.com/jagrosh/MusicBot/discussions/1257

