### PR TITLE
Sanitize the playlist name

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/PlaylistCmd.java
@@ -72,6 +72,7 @@ public class PlaylistCmd extends OwnerCommand
         protected void execute(CommandEvent event) 
         {
             String pname = event.getArgs().replaceAll("\\s+", "_");
+            pname = pname.replaceAll("[*?|\\/\":<>]", "");
             if(pname == null || pname.isEmpty()) 
             {
                 event.replyError("Please provide a name for the playlist!");


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Remove invalid characters such as \ / : * ? " < > | from the playlist name by using regex.

### Purpose
[On Windows, there are reserved characters that cannot be used for file naming](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file). The InvalidPathException will occur if these characters are used for file naming. Rather than catching this exception and sending a warning for invalid characters, we will instead sanitize the file name input for a better user experience (e.g. the user may have mistyped).

### Relevant Issue(s)
This PR closes issue #1272
