### PR TITLE
Catch JDA exception when there is no internet connection

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.api.*;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +203,7 @@ public class JMusicBot
         }
         catch(ErrorResponseException ex)
         {
-            prompt.alert(Prompt.Level.ERROR, "JMusicBot", ex + "\n Invalid reponse returned when "
+            prompt.alert(Prompt.Level.ERROR, "JMusicBot", ex + "\nInvalid reponse returned when "
                     + "attempting to connect, please make sure you're connected to the internet");
             System.exit(1);
         }

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -200,5 +200,11 @@ public class JMusicBot
                     + "invalid: " + ex + "\nConfig Location: " + config.getConfigLocation());
             System.exit(1);
         }
+        catch(ErrorResponseException ex)
+        {
+            prompt.alert(Prompt.Level.ERROR, "JMusicBot", ex + "\n Invalid reponse returned when "
+                    + "attempting to connect, please make sure you're connected to the internet");
+            System.exit(1);
+        }
     }
 }


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Added catch clause to JMusicBot.java

### Purpose
When running the bot without an internet connection, the JDA connection attempt will fail without catching the exception and doing a proper system exit. This means that if the bot cannot establish a connection, the program will wait instead of exiting. Automated restart scripts will not work as a result.

### Relevant Issue(s)
This PR closes issue #1303
