### PR TITLE
Introduce default code font

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
   custom_dir: docs/overrides
   font:
     text: 'Fira Sans'
+    code: 'Fira Code'
   name: material
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
Has the same license as fira sans, beause its fira code

### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [x] Boosts code quality or performance

### Description & Purpose
Actually setting a code font, instead of letting systems pick funky fonts.

### Relevant Issue(s)
#1256 
