### PR TITLE
Add mintime similar to maxtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.json
 *.txt
 nb*.xml
+.idea

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -42,7 +42,7 @@ public class BotConfig
     private String token, prefix, altprefix, helpWord, playlistsFolder,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
-    private long owner, maxSeconds, aloneTimeUntilStop;
+    private long owner, maxSeconds, minSeconds, aloneTimeUntilStop;
     private OnlineStatus status;
     private Activity game;
     private Config aliases, transforms;
@@ -87,6 +87,7 @@ public class BotConfig
             updatealerts = config.getBoolean("updatealerts");
             useEval = config.getBoolean("eval");
             maxSeconds = config.getLong("maxtime");
+            minSeconds = config.getLong("mintime");
             aloneTimeUntilStop = config.getLong("alonetimeuntilstop");
             playlistsFolder = config.getString("playlistsfolder");
             aliases = config.getConfig("aliases");
@@ -315,10 +316,20 @@ public class BotConfig
     {
         return maxSeconds;
     }
+
+    public long getMinSeconds()
+    {
+        return minSeconds;
+    }
     
     public String getMaxTime()
     {
         return FormatUtil.formatTime(maxSeconds * 1000);
+    }
+
+    public String getMinTime()
+    {
+        return FormatUtil.formatTime(minSeconds * 1000);
     }
 
     public long getAloneTimeUntilStop()
@@ -331,6 +342,13 @@ public class BotConfig
         if(maxSeconds<=0)
             return false;
         return Math.round(track.getDuration()/1000.0) > maxSeconds;
+    }
+
+    public boolean isTooShort(AudioTrack track)
+    {
+        if(minSeconds<=0)
+            return false;
+        return Math.round(track.getDuration()/1000.0) < minSeconds;
     }
 
     public String[] getAliases(String command)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
@@ -82,6 +82,12 @@ public class PlaynextCmd extends DJCommand
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+FormatUtil.formatTime(bot.getConfig().getMaxSeconds()*1000)+"`")).queue();
                 return;
             }
+            if(bot.getConfig().isTooShort(track))
+            {
+                m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is shorter than the allowed minimum: `"
+                        +FormatUtil.formatTime(track.getDuration())+"` < `"+FormatUtil.formatTime(bot.getConfig().getMinSeconds()*1000)+"`")).queue();
+                return;
+            }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
             int pos = handler.addTrackToFront(new QueuedTrack(track, event.getAuthor()))+1;
             String addMsg = FormatUtil.filter(event.getClient().getSuccess()+" Added **"+track.getInfo().title

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -111,6 +111,12 @@ public class PlayCmd extends MusicCommand
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+FormatUtil.formatTime(bot.getConfig().getMaxSeconds()*1000)+"`")).queue();
                 return;
             }
+            if(bot.getConfig().isTooShort(track))
+            {
+                m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is shorter than the allowed minimum: `"
+                        +FormatUtil.formatTime(track.getDuration())+"` < `"+FormatUtil.formatTime(bot.getConfig().getMinSeconds()*1000)+"`")).queue();
+                return;
+            }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
             int pos = handler.addTrack(new QueuedTrack(track, event.getAuthor()))+1;
             String addMsg = FormatUtil.filter(event.getClient().getSuccess()+" Added **"+track.getInfo().title
@@ -141,7 +147,7 @@ public class PlayCmd extends MusicCommand
         {
             int[] count = {0};
             playlist.getTracks().stream().forEach((track) -> {
-                if(!bot.getConfig().isTooLong(track) && !track.equals(exclude))
+                if(!bot.getConfig().isTooLong(track) && !bot.getConfig().isTooShort(track) && !track.equals(exclude))
                 {
                     AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
                     handler.addTrack(new QueuedTrack(track, event.getAuthor()));

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/SearchCmd.java
@@ -91,6 +91,12 @@ public class SearchCmd extends MusicCommand
                         +FormatUtil.formatTime(track.getDuration())+"` > `"+bot.getConfig().getMaxTime()+"`")).queue();
                 return;
             }
+            if(bot.getConfig().isTooShort(track))
+            {
+                m.editMessage(FormatUtil.filter(event.getClient().getWarning()+" This track (**"+track.getInfo().title+"**) is shorter than the allowed minimum: `"
+                        +FormatUtil.formatTime(track.getDuration())+"` < `"+bot.getConfig().getMinTime()+"`")).queue();
+                return;
+            }
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
             int pos = handler.addTrack(new QueuedTrack(track, event.getAuthor()))+1;
             m.editMessage(FormatUtil.filter(event.getClient().getSuccess()+" Added **"+track.getInfo().title
@@ -111,6 +117,12 @@ public class SearchCmd extends MusicCommand
                         {
                             event.replyWarning("This track (**"+track.getInfo().title+"**) is longer than the allowed maximum: `"
                                     +FormatUtil.formatTime(track.getDuration())+"` > `"+bot.getConfig().getMaxTime()+"`");
+                            return;
+                        }
+                        if(bot.getConfig().isTooShort(track))
+                        {
+                            event.replyWarning("This track (**"+track.getInfo().title+"**) is shorter than the allowed minimum: `"
+                                    +FormatUtil.formatTime(track.getDuration())+"` < `"+bot.getConfig().getMinTime()+"`");
                             return;
                         }
                         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();

--- a/src/main/java/com/jagrosh/jmusicbot/playlist/PlaylistLoader.java
+++ b/src/main/java/com/jagrosh/jmusicbot/playlist/PlaylistLoader.java
@@ -182,6 +182,8 @@ public class PlaylistLoader
                     {
                         if(config.isTooLong(at))
                             errors.add(new PlaylistLoadError(index, items.get(index), "This track is longer than the allowed maximum"));
+                        else if(config.isTooShort(at))
+                            errors.add(new PlaylistLoadError(index, items.get(index), "This track is shorter than the allowed minimum"));
                         else
                         {
                             at.setUserData(0L);
@@ -213,7 +215,7 @@ public class PlaylistLoader
                                     loaded.set(first, loaded.get(second));
                                     loaded.set(second, tmp);
                                 }
-                            loaded.removeIf(track -> config.isTooLong(track));
+                            loaded.removeIf(track -> config.isTooLong(track) || config.isTooShort(track));
                             loaded.forEach(at -> at.setUserData(0L));
                             tracks.addAll(loaded);
                             loaded.forEach(at -> consumer.accept(at));

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -99,6 +99,13 @@ stayinchannel = false
 maxtime = 0
 
 
+// This sets the minimum amount of seconds any track loaded can be. If not set or set
+// to any number less than or equal to zero, there is no minimum time length. This time
+// restriction applies to songs loaded from any source.
+
+mintime = 0
+
+
 // This sets the amount of seconds the bot will stay alone on a voice channel until it
 // automatically leaves the voice channel and clears the queue. If not set or set
 // to any number less than or equal to zero, the bot won't leave when alone.


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This pull request adds a config option "mintime" which works as the opposite of existing "maxtime".

### Purpose
Not sure if anyone else will find this useful but I use this myself to limit the amount of short spam videos people attempt to play.

