### PR TITLE
Switch to Community Maintained fork of bump-lavaplayer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,18 +41,11 @@
             <type>pom</type>
         </dependency>
 
-        <!-- Music Dependencies -->
-        <!-- using a fork of this to fix some issues faster -->
-        <!-- dependency>
-            <groupId>com.sedmelluq</groupId>
-            <artifactId>lavaplayer</artifactId>
-            <version>1.3.78</version>
-        </dependency -->
         <dependency>
-	    <groupId>com.github.jagrosh</groupId>
-	    <artifactId>lavaplayer</artifactId>
-	    <version>jmusicbot-SNAPSHOT</version>
-	</dependency>
+            <groupId>dev.arbjerg</groupId>
+            <artifactId>lavaplayer</artifactId>
+            <version>2.0.1</version>
+        </dependency>
         <!-- this is needed, but isn't actually hosted anywhere anymore... uh -->
         <!--dependency>
             <groupId>com.sedmelluq</groupId>


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
I tried setting this up as an alternative to using red-discordbot and ended up immediately running into #885.

There is also #1375 which advocates for moving to youtube-dl+ffmpeg as a replacement for lavaplayer, but that would take quite a bit of work as it is called out in the issue.

After the OG lavaplayer repo was abandoned, the community forked it and has been maintaining it since:

https://github.com/lavalink-devs/lavaplayer

This commit moves us from using this project's forked version to the community's fork.

I tested this with some tracks that were returning HTTP 403s and it is now resolved (at least in my testing...)

### Purpose
Bumping this to a more recent version allows us to pull in a fix from lavalink-devs/lavaplayer/pull/16

### Relevant Issue(s)
This PR closes issue #885 
