### PR TITLE
Remove channel topic info

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/Bot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Bot.java
@@ -139,7 +139,6 @@ public class Bot
                 {
                     ah.stopAndClear();
                     ah.getPlayer().destroy();
-                    nowplaying.updateTopic(g.getIdLong(), ah, true);
                 }
             });
             jda.shutdown();

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -47,7 +47,7 @@ public class JMusicBot
     public final static Logger LOG = LoggerFactory.getLogger(JMusicBot.class);
     public final static Permission[] RECOMMENDED_PERMS = {Permission.MESSAGE_READ, Permission.MESSAGE_WRITE, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
-                                Permission.MANAGE_CHANNEL, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
+                                Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
     public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES};
     
     /**

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -15,7 +15,6 @@
  */
 package com.jagrosh.jmusicbot.audio;
 
-import com.jagrosh.jmusicbot.JMusicBot;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader.Playlist;
 import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
@@ -175,7 +174,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
         {
             if(!playFromDefault())
             {
-                manager.getBot().getNowplayingHandler().onTrackUpdate(guildId, null, this);
+                manager.getBot().getNowplayingHandler().onTrackUpdate(null);
                 if(!manager.getBot().getConfig().getStay())
                     manager.getBot().closeAudioConnection(guildId);
                 // unpause, in the case when the player was paused and the track has been skipped.

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -194,7 +194,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
     public void onTrackStart(AudioPlayer player, AudioTrack track) 
     {
         votes.clear();
-        manager.getBot().getNowplayingHandler().onTrackUpdate(guildId, track, this);
+        manager.getBot().getNowplayingHandler().onTrackUpdate(track);
     }
 
     
@@ -258,24 +258,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
                 .setColor(guild.getSelfMember().getColor())
                 .build()).build();
     }
-    
-    public String getTopicFormat(JDA jda)
-    {
-        if(isMusicPlaying(jda))
-        {
-            long userid = getRequestMetadata().getOwner();
-            AudioTrack track = audioPlayer.getPlayingTrack();
-            String title = track.getInfo().title;
-            if(title==null || title.equals("Unknown Title"))
-                title = track.getInfo().uri;
-            return "**"+title+"** ["+(userid==0 ? "autoplay" : "<@"+userid+">")+"]"
-                    + "\n" + getStatusEmoji() + " "
-                    + "[" + FormatUtil.formatTime(track.getDuration()) + "] "
-                    + FormatUtil.volumeIcon(audioPlayer.getVolume());
-        }
-        else return "No music playing " + STOP_EMOJI + " " + FormatUtil.volumeIcon(audioPlayer.getVolume());
-    }
-    
+
     public String getStatusEmoji()
     {
         return audioPlayer.isPaused() ? PAUSE_EMOJI : PLAY_EMOJI;

--- a/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
@@ -98,42 +98,9 @@ public class NowplayingHandler
         }
         toRemove.forEach(id -> lastNP.remove(id));
     }
-    
-    public void updateTopic(long guildId, AudioHandler handler, boolean wait)
-    {
-        Guild guild = bot.getJDA().getGuildById(guildId);
-        if(guild==null)
-            return;
-        Settings settings = bot.getSettingsManager().getSettings(guildId);
-        TextChannel tchan = settings.getTextChannel(guild);
-        if(tchan!=null && guild.getSelfMember().hasPermission(tchan, Permission.MANAGE_CHANNEL))
-        {
-            String otherText;
-            String topic = tchan.getTopic();
-            if(topic==null || topic.isEmpty())
-                otherText = "\u200B";
-            else if(topic.contains("\u200B"))
-                otherText = topic.substring(topic.lastIndexOf("\u200B"));
-            else
-                otherText = "\u200B\n "+topic;
-            String text = handler.getTopicFormat(bot.getJDA()) + otherText;
-            if(!text.equals(tchan.getTopic()))
-            {
-                try 
-                {
-                    // normally here if 'wait' was false, we'd want to queue, however,
-                    // new discord ratelimits specifically limiting changing channel topics
-                    // mean we don't want a backlog of changes piling up, so if we hit a 
-                    // ratelimit, we just won't change the topic this time
-                    tchan.getManager().setTopic(text).complete(wait);
-                } 
-                catch(PermissionException | RateLimitedException ignore) {}
-            }
-        }
-    }
-    
+
     // "event"-based methods
-    public void onTrackUpdate(long guildId, AudioTrack track, AudioHandler handler)
+    public void onTrackUpdate(AudioTrack track)
     {
         // update bot status if applicable
         if(bot.getConfig().getSongInStatus())
@@ -143,9 +110,6 @@ public class NowplayingHandler
             else
                 bot.resetGame();
         }
-        
-        // update channel topic if applicable
-        updateTopic(guildId, handler, false);
     }
     
     public void onMessageDelete(Guild guild, long messageId)


### PR DESCRIPTION
As Discord has severely increased the ratelimits for updating the channel topic, updating the channel topic has become not viable for bots.

Closes #1018 although it doesn't remove old topics unfortunately, server admins will have to remove them manually.