### PR TITLE
Make JMusicBot error & shut down if ran in an unsupported manner

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -187,6 +187,14 @@ public class JMusicBot
                     .setBulkDeleteSplittingEnabled(true)
                     .build();
             bot.setJDA(jda);
+
+            String unsupportedReason = OtherUtil.getUnsupportedBotReason(jda);
+            if (unsupportedReason != null)
+            {
+                jda.shutdown();
+                prompt.alert(Prompt.Level.ERROR, "JMusicBot", "JMusicBot cannot be run on this Discord bot: " + unsupportedReason);
+                System.exit(1);
+            }
         }
         catch (LoginException ex)
         {

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -188,12 +188,23 @@ public class JMusicBot
                     .build();
             bot.setJDA(jda);
 
+            // check if something about the current startup is not supported
             String unsupportedReason = OtherUtil.getUnsupportedBotReason(jda);
             if (unsupportedReason != null)
             {
                 jda.shutdown();
                 prompt.alert(Prompt.Level.ERROR, "JMusicBot", "JMusicBot cannot be run on this Discord bot: " + unsupportedReason);
                 System.exit(1);
+            }
+            
+            // other check that will just be a warning now but may be required in the future
+            // check if the user has changed the prefix and provide info about the 
+            // message content intent
+            if(!"@mention".equals(config.getPrefix()))
+            {
+                prompt.alert(Prompt.Level.INFO, "JMusicBot", "You currently have a custom prefix set. "
+                        + "If your prefix is not working, make sure that the 'MESSAGE CONTENT INTENT' is Enabled "
+                        + "on https://discord.com/developers/applications/" + jda.getSelfUser().getId() + "/bot");
             }
         }
         catch (LoginException ex)

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -192,8 +192,9 @@ public class JMusicBot
             String unsupportedReason = OtherUtil.getUnsupportedBotReason(jda);
             if (unsupportedReason != null)
             {
-                jda.shutdown();
                 prompt.alert(Prompt.Level.ERROR, "JMusicBot", "JMusicBot cannot be run on this Discord bot: " + unsupportedReason);
+                try{ Thread.sleep(5000);}catch(InterruptedException ignored){} // this is awful but until we have a better way...
+                jda.shutdown();
                 System.exit(1);
             }
             

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -216,8 +216,8 @@ public class OtherUtil
      * Checks if the bot JMusicBot is being run on is supported & returns the reason if it is not.
      * @return A string with the reason, or null if it is supported.
      */
-    public static String getUnsupportedBotReason(JDA jda) {
-
+    public static String getUnsupportedBotReason(JDA jda) 
+    {
         if (jda.getSelfUser().getFlags().contains(User.UserFlag.VERIFIED_BOT))
             return "The bot is verified. Using JMusicBot in a verified bot is not supported.";
 

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -23,8 +23,12 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.ApplicationInfo;
+import net.dv8tion.jda.api.entities.User;
 import okhttp3.*;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -206,5 +210,21 @@ public class OtherUtil
         {
             return null;
         }
+    }
+
+    /**
+     * Checks if the bot JMusicBot is being run on is supported & returns the reason if it is not.
+     * @return A string with the reason, or null if it is supported.
+     */
+    public static String getUnsupportedBotReason(JDA jda) {
+
+        if (jda.getSelfUser().getFlags().contains(User.UserFlag.VERIFIED_BOT))
+            return "The bot is verified. Using JMusicBot in a verified bot is not supported.";
+
+        ApplicationInfo info = jda.retrieveApplicationInfo().complete();
+        if (info.isBotPublic())
+            return "\"Public Bot\" is enabled. Using JMusicBot as a public bot is not supported. Please disable it in the Developer Dashboard.";
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR adds a `getUnsupportedBotReason` utility, which determines if the bot JMusicBot is running under shows any remarks of being run in a manner that JMusicBot doesn't support. JDA will get shut down & JMusicBot will exit if there is a reason.

Right now, it only checks:

- If the bot is verified
- If the bot is public

It doesn't look like there's a way to check privileged intents with JDA 4? Thus its absent for now.