### PR TITLE
Don't warn about failing to load server settings when the file isn't found

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -165,8 +165,10 @@ public class JMusicBot
                 GUI gui = new GUI(bot);
                 bot.setGUI(gui);
                 gui.init();
-            } 
-            catch(Exception e) 
+
+                LOG.info("Loaded config from " + config.getConfigLocation());
+            }
+            catch(Exception e)
             {
                 LOG.error("Could not start GUI. If you are "
                         + "running on a server or in a location where you cannot display a "

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -19,6 +19,7 @@ import com.jagrosh.jdautilities.command.GuildSettingsManager;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import net.dv8tion.jda.api.entities.Guild;
 import org.json.JSONException;
@@ -58,10 +59,19 @@ public class SettingsManager implements GuildSettingsManager<Settings>
                         o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
             });
         } catch (NoSuchFileException e) {
-            // ignore, it just means no settings have been saved yet
+            // create an empty json file
+            try {
+                LoggerFactory.getLogger("Settings").info("serversettings.json will be created in " + OtherUtil.getPath("serversettings.json").toAbsolutePath());
+                Files.write(OtherUtil.getPath("serversettings.json"), new JSONObject().toString(4).getBytes());
+            } catch(IOException ex) {
+                LoggerFactory.getLogger("Settings").warn("Failed to create new settings file: "+ex);
+            }
+            return;
         } catch(IOException | JSONException e) {
             LoggerFactory.getLogger("Settings").warn("Failed to load server settings: "+e);
         }
+
+        LoggerFactory.getLogger("Settings").info("serversettings.json loaded from " + OtherUtil.getPath("serversettings.json").toAbsolutePath());
     }
     
     /**

--- a/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/SettingsManager.java
@@ -57,8 +57,10 @@ public class SettingsManager implements GuildSettingsManager<Settings>
                         o.has("prefix")          ? o.getString("prefix")                     : null,
                         o.has("skip_ratio")      ? o.getDouble("skip_ratio")                 : SKIP_RATIO));
             });
+        } catch (NoSuchFileException e) {
+            // ignore, it just means no settings have been saved yet
         } catch(IOException | JSONException e) {
-            LoggerFactory.getLogger("Settings").warn("Failed to load server settings (this is normal if no settings have been set yet): "+e);
+            LoggerFactory.getLogger("Settings").warn("Failed to load server settings: "+e);
         }
     }
     


### PR DESCRIPTION
Users get confused by the `Failed to load server settings (this is normal if no settings have been set yet)` warning, which almost always gets logged when the serversettings.json file doesn't exist. The file not existing is perfectly fine for JMusicBot, so I propose we don't log this when the file wasn't found.