### PR TITLE
Switch to lavalink's lavaplayer fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
+        <repository>
+            <id>arbjergDev-snapshots</id>
+            <name>Lavalink Repository</name>
+            <url>https://maven.lavalink.dev/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -42,17 +47,11 @@
         </dependency>
 
         <!-- Music Dependencies -->
-        <!-- using a fork of this to fix some issues faster -->
-        <!-- dependency>
-            <groupId>com.sedmelluq</groupId>
-            <artifactId>lavaplayer</artifactId>
-            <version>1.3.78</version>
-        </dependency -->
         <dependency>
-	    <groupId>com.github.jagrosh</groupId>
-	    <artifactId>lavaplayer</artifactId>
-	    <version>jmusicbot-SNAPSHOT</version>
-	</dependency>
+            <groupId>dev.arbjerg</groupId>
+            <artifactId>lavaplayer</artifactId>
+            <version>727959e9f621fc457b3a5adafcfffb55fdeaa538-SNAPSHOT</version>
+        </dependency>
         <!-- this is needed, but isn't actually hosted anywhere anymore... uh -->
         <!--dependency>
             <groupId>com.sedmelluq</groupId>

--- a/src/main/java/com/jagrosh/jmusicbot/utils/LogBackTurboFilter.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/LogBackTurboFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jagrosh.jmusicbot.utils;
 
 import ch.qos.logback.classic.Level;
@@ -11,10 +26,11 @@ import org.slf4j.Marker;
  *
  * @author Michaili K. <git@michaili.dev>
  */
-public class LogBackTurboFilter extends TurboFilter {
-
+public class LogBackTurboFilter extends TurboFilter 
+{
     @Override
-    public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+    public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) 
+    {
         // Suppresses the auth token warning from the YoutubeAudioSourceManager
         // https://github.com/jagrosh/MusicBot/pull/1490#issuecomment-1974070225
         if (logger.getName().equals("com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAccessTokenTracker")

--- a/src/main/java/com/jagrosh/jmusicbot/utils/LogBackTurboFilter.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/LogBackTurboFilter.java
@@ -1,0 +1,28 @@
+package com.jagrosh.jmusicbot.utils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import org.slf4j.Marker;
+
+/**
+ * A TurboFilter, currently only used to suppress specific log messages from libraries.
+ *
+ * @author Michaili K. <git@michaili.dev>
+ */
+public class LogBackTurboFilter extends TurboFilter {
+
+    @Override
+    public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+        // Suppresses the auth token warning from the YoutubeAudioSourceManager
+        // https://github.com/jagrosh/MusicBot/pull/1490#issuecomment-1974070225
+        if (logger.getName().equals("com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAccessTokenTracker")
+                && format.equals("YouTube auth tokens can't be retrieved because email and password is not set in YoutubeAudioSourceManager, age restricted videos will throw exceptions.")
+        ) {
+            return FilterReply.DENY;
+        }
+
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,4 +14,6 @@
         <appender-ref ref="Simple"/>
     </root>
 
+    <turboFilter class="com.jagrosh.jmusicbot.utils.LogBackTurboFilter" />
+
 </configuration>


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Switches lavaplayer dependency from our fork to lavalink's fork.

It uses the (as of writing) latest commit instead of the latest stable version, as I've encountered https://github.com/lavalink-devs/lavaplayer/issues/69 during my testing, which prevented playing *any* YouTube tracks.

### Purpose
Fixes several issues related to our outdated fork, particularly the "Error loading track from YouTube (403)"

### Relevant Issue(s)
Fixes #885

Maybe fixes #1291

And honestly, closes #1375 because switching to ffmpeg requires monumental effort & im pretty sure there's other music bots that do precisely that anyways.
