### PR TITLE
Always self-deafen

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -86,6 +86,7 @@ public abstract class MusicCommand extends Command
                 try 
                 {
                     event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
+                    event.getGuild().getAudioManager().setSelfDeafened(true);
                 }
                 catch(PermissionException ex) 
                 {


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Self-deafen when joining voice channels.

### Purpose
Saves bandwidth & makes people less paranoid over the bot listening to them.

### Relevant Issue(s)
Resolves #519
