### PR TITLE
Fix startup message type and add URL to message

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -137,7 +137,7 @@ public class JMusicBot
             // message content intent
             if(!"@mention".equals(config.getPrefix()))
             {
-                prompt.alert(Prompt.Level.INFO, "JMusicBot", "You currently have a custom prefix set. "
+                LOG.info("JMusicBot", "You currently have a custom prefix set. "
                         + "If your prefix is not working, make sure that the 'MESSAGE CONTENT INTENT' is Enabled "
                         + "on https://discord.com/developers/applications/" + jda.getSelfUser().getId() + "/bot");
             }

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -223,7 +223,8 @@ public class OtherUtil
 
         ApplicationInfo info = jda.retrieveApplicationInfo().complete();
         if (info.isBotPublic())
-            return "\"Public Bot\" is enabled. Using JMusicBot as a public bot is not supported. Please disable it in the Developer Dashboard.";
+            return "\"Public Bot\" is enabled. Using JMusicBot as a public bot is not supported. Please disable it in the "
+                    + "Developer Dashboard at https://discord.com/developers/applications/" + jda.getSelfUser().getId() + "/bot.";
 
         return null;
     }


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [ ] Introduces a new feature
  - [X] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Fix startup message type and add URL to message

### Purpose
Right now the bot stalls at startup for GUI users due to a prompt about message intent; this should be a log message instead.

### Relevant Issue(s)
