### PR TITLE
Custom Eval Engine

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -40,7 +40,8 @@ public class BotConfig
     
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder,
-            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
+            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji,
+            evalEngine;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private double skipratio;
@@ -87,6 +88,7 @@ public class BotConfig
             npImages = config.getBoolean("npimages");
             updatealerts = config.getBoolean("updatealerts");
             useEval = config.getBoolean("eval");
+            evalEngine = config.getString("evalengine");
             maxSeconds = config.getLong("maxtime");
             aloneTimeUntilStop = config.getLong("alonetimeuntilstop");
             playlistsFolder = config.getString("playlistsfolder");
@@ -316,6 +318,11 @@ public class BotConfig
     public boolean useEval()
     {
         return useEval;
+    }
+    
+    public String getEvalEngine()
+    {
+        return evalEngine;
     }
     
     public boolean useNPImages()

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.api.entities.ChannelType;
 public class EvalCmd extends OwnerCommand 
 {
     private final Bot bot;
+    private final String engine;
     
     public EvalCmd(Bot bot)
     {
@@ -36,13 +37,20 @@ public class EvalCmd extends OwnerCommand
         this.name = "eval";
         this.help = "evaluates nashorn code";
         this.aliases = bot.getConfig().getAliases(this.name);
+        this.engine = bot.getConfig().getEvalEngine();
         this.guildOnly = false;
     }
     
     @Override
     protected void execute(CommandEvent event) 
     {
-        ScriptEngine se = new ScriptEngineManager().getEngineByName("Nashorn");
+        ScriptEngine se = new ScriptEngineManager().getEngineByName(engine);
+        if(se == null)
+        {
+            event.replyError("The eval engine provided in the config (`"+engine+"`) doesn't exist. This could be due to an invalid "
+                    + "engine name, or the engine not existing in your version of java (`"+System.getProperty("java.version")+"`).");
+            return;
+        }
         se.put("bot", bot);
         se.put("event", event);
         se.put("jda", event.getJDA());

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -206,6 +206,7 @@ transforms = {}
 // IF SOMEONE ASKS YOU TO ENABLE THIS, THERE IS AN 11/10 CHANCE THEY ARE TRYING TO SCAM YOU
 
 eval=false
+evalengine="Nashorn"
 
 
 /// END OF JMUSICBOT CONFIG ///


### PR DESCRIPTION
### This pull request...
  - [X] Fixes a bug
  - [X] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Allows setting the eval engine in the config, and adds an error message if the provided engine does not exist

### Purpose
Later versions of Java don't include the Nashorn engine; this PR allows setting the engine to be used.

### Relevant Issue(s)
This PR closes issue #1501, #945 
