### PR TITLE
Add config option whether the bot should deafen itself

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -41,7 +41,7 @@ public class BotConfig
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
-    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
+    private boolean stayInChannel, deafen, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private double skipratio;
     private OnlineStatus status;
@@ -83,6 +83,7 @@ public class BotConfig
             game = OtherUtil.parseGame(config.getString("game"));
             status = OtherUtil.parseStatus(config.getString("status"));
             stayInChannel = config.getBoolean("stayinchannel");
+            deafen = config.getBoolean("deafen");
             songInGame = config.getBoolean("songinstatus");
             npImages = config.getBoolean("npimages");
             updatealerts = config.getBoolean("updatealerts");
@@ -293,7 +294,12 @@ public class BotConfig
     {
         return stayInChannel;
     }
-    
+
+    public boolean getDeafen()
+    {
+        return deafen;
+    }
+
     public boolean getSongInStatus()
     {
         return songInGame;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -86,7 +86,8 @@ public abstract class MusicCommand extends Command
                 try 
                 {
                     event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
-                    event.getGuild().getAudioManager().setSelfDeafened(true);
+                    if (bot.getConfig().getDeafen())
+                        event.getGuild().getAudioManager().setSelfDeafened(true);
                 }
                 catch(PermissionException ex) 
                 {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -91,6 +91,11 @@ npimages = false
 
 stayinchannel = false
 
+// This sets whether the bot will deafen itself in voice channels.
+// Deafening saves network bandwidth, and some users prefer bots to be deafened.
+
+deafen = true
+
 
 // This sets the maximum amount of seconds any track loaded can be. If not set or set
 // to any number less than or equal to zero, there is no maximum time length. This time


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [x] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Adds a config option which allows users to configure whether the bot should deafen itself or not.

### Purpose
Although it is better for the bot to be deafened due to network bandwidth savings & increased privacy, some people are annoyed by the deafened icon and would prefer to disable deafen.

### Relevant Issue(s)
N/A, i remember there were a few complaints about this on the Discord server.
