### PR TITLE
Revert "Always self-deafen (#1491)"

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -86,7 +86,6 @@ public abstract class MusicCommand extends Command
                 try 
                 {
                     event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
-                    event.getGuild().getAudioManager().setSelfDeafened(true);
                 }
                 catch(PermissionException ex) 
                 {


### PR DESCRIPTION
This PR reverts the always self-deafen. [An earlier comment of mine](https://github.com/jagrosh/MusicBot/pull/1545#issuecomment-2057789129) has proven that self-deafening doesn't actually help:

<hr/>

You know, it would be awesome if [the response of Discord's support team](https://github.com/jagrosh/MusicBot/issues/519#issuecomment-716128114) were correct:
> Hello,
>
> thank you for your patience.
>
> To answer your question: Yes, it has an impact and helps us save bandwidth in voice channels.
>
> Unfortunately, we cannot provide you with any more information. But please let us know if you have any further questions about the app! :) 
    
Well, unfortunately, it looks like that's not actually the case & deafening yourself is not enough. You'll have to server deafen in order to not receive any traffic:

https://github.com/jagrosh/MusicBot/assets/39029839/1059a81a-ab63-4d0a-b521-42ceba86d2d7

(Notice how Network rx goes up as I speak, until i server deafen the bot)

That is... a pretty disappointing discovery how the support rep has blundered & actually only server deafening saves bandwidth...