### PR TITLE
Add support for Piped links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.json
 *.txt
 nb*.xml
+.DS_Store

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -40,7 +40,7 @@ public class BotConfig
     
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
-            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
+            successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji, pipedURL;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private double skipratio;
@@ -80,6 +80,7 @@ public class BotConfig
             errorEmoji = config.getString("error");
             loadingEmoji = config.getString("loading");
             searchingEmoji = config.getString("searching");
+            pipedURL = config.getString("piped");
             game = OtherUtil.parseGame(config.getString("game"));
             status = OtherUtil.parseStatus(config.getString("status"));
             stayInChannel = config.getBoolean("stayinchannel");
@@ -267,6 +268,11 @@ public class BotConfig
     public String getSearching()
     {
         return searchingEmoji;
+    }
+
+    public String getPiped()
+    {
+        return "NONE".equalsIgnoreCase(pipedURL) ? null : pipedURL;
     }
     
     public Activity getGame()

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -177,11 +177,13 @@ public class JMusicBot
                                 RECOMMENDED_PERMS);
         aboutCommand.setIsAuthor(false);
         aboutCommand.setReplacementCharacter("\uD83C\uDFB6"); // 🎶
-        
+
         // set up the command client
+        //TODO: Add piped command
         CommandClientBuilder cb = new CommandClientBuilder()
                 .setPrefix(config.getPrefix())
                 .setAlternativePrefix(config.getAltPrefix())
+                // .setPipedURL(config.getPiped())
                 .setOwnerId(Long.toString(config.getOwnerId()))
                 .setEmojis(config.getSuccess(), config.getWarning(), config.getError())
                 .setHelpWord(config.getHelp())

--- a/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/dj/PlaynextCmd.java
@@ -58,6 +58,9 @@ public class PlaynextCmd extends DJCommand
         String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">") 
                 ? event.getArgs().substring(1,event.getArgs().length()-1) 
                 : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
+        if (args == event.getMessage().getAttachments().get(0).getUrl() && bot.getConfig().getPiped() != null && args.contains(bot.getConfig().getPiped())) {
+            args.replace(bot.getConfig().getPiped(), "youtube.com");
+        }
         event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/PlayCmd.java
@@ -84,9 +84,13 @@ public class PlayCmd extends MusicCommand
             event.reply(builder.toString());
             return;
         }
+        //TODO: Reformat this to if statements, if URL matches piped URL, replace with youtube. Repeat for all other play/queue commands
         String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">") 
                 ? event.getArgs().substring(1,event.getArgs().length()-1) 
                 : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
+        if (args == event.getMessage().getAttachments().get(0).getUrl() && bot.getConfig().getPiped() != null && args.contains(bot.getConfig().getPiped())) {
+            args.replace(bot.getConfig().getPiped(), "youtube.com");
+        }
         event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
     }
     

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
@@ -57,6 +57,7 @@ public class DebugCmd extends OwnerCommand
                 .append("\n  Owner = ").append(bot.getConfig().getOwnerId())
                 .append("\n  Prefix = ").append(bot.getConfig().getPrefix())
                 .append("\n  AltPrefix = ").append(bot.getConfig().getAltPrefix())
+                .append("\n  PipedURL = ").append(bot.getConfig().getPiped())
                 .append("\n  MaxSeconds = ").append(bot.getConfig().getMaxSeconds())
                 .append("\n  NPImages = ").append(bot.getConfig().useNPImages())
                 .append("\n  SongInStatus = ").append(bot.getConfig().getSongInStatus())

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetpipedCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/SetpipedCmd.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 John Grosh <john.a.grosh@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands.owner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.commands.OwnerCommand;
+import com.jagrosh.jmusicbot.utils.OtherUtil;
+import net.dv8tion.jda.api.entities.Icon;
+
+/**
+ *
+ * @author John Grosh <john.a.grosh@gmail.com>
+ */
+public class Setpipedcmd extends OwnerCommand 
+{
+    public SetpipedCmd(Bot bot)
+    {
+        this.name = "setpiped";
+        this.help = "sets the Piped instance's URL";
+        this.arguments = "<url>";
+        this.aliases = bot.getConfig().getAliases(this.name);
+        this.guildOnly = false;
+    }
+    
+    @Override
+    protected void execute(CommandEvent event) 
+    {
+        String url;
+        if(event.getArgs().isEmpty())
+            url = null;
+        else
+            url = event.getArgs();
+        //TODO: Add util to fetch Piped URL
+        boolean isPiped = OtherUtil.isPipedInstance(url);
+        if(!isPiped)
+        {
+            event.reply(event.getClient().getError()+" Invalid Piped URL");
+        }
+        else
+        {
+            pipedURL = url;
+            event.reply(event.getClient().getSuccess()+" Successfully changed Piped URL.")
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -228,4 +228,41 @@ public class OtherUtil
 
         return null;
     }
+
+    public static boolean isPipedInstance(String url)
+    {
+        try
+        {
+            Response response = new OkHttpClient.Builder().build()
+                    .newCall(new Request.Builder().get().url(url + "/trending").build())
+                    .execute();
+            ResponseBody body = response.body();
+            if(body != null)
+            {
+                try(Reader reader = body.charStream())
+                {
+                    JSONObject obj = new JSONObject(new JSONTokener(reader));
+                    try {
+                        if (obj.getString("error") == "region is a required parameter") {
+                            return true;
+                        }
+                        return false;
+                    }
+                    catch (Exception e) {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    response.close();
+                }
+            }
+            else
+                return false;
+        }
+        catch(IOException | JSONException | NullPointerException ex)
+        {
+            return false;
+        }
+    }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -61,6 +61,11 @@ songinstatus=false
 altprefix = "NONE"
 
 
+// If you set this, the bot will play streams from this Piped instance
+
+pipedURL = "NONE"
+
+
 // If you set these, it will change the various emojis
 
 success = "🎶"


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Allows users to send Piped links to the music bot

### Purpose
Users who prefer to use Piped over YouTube can send their instance's links to the bot

### Relevant Issue(s)
This PR closes issue #1492
