### PR TITLE
Switch to alternative lavalink youtube source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
             <version>2.1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.github.lavalink-devs</groupId>
-            <artifactId>lavaplayer-youtube-source</artifactId>
-            <version>1.0.4</version>
+            <groupId>dev.lavalink.youtube</groupId>
+            <artifactId>v2</artifactId>
+            <version>b2c8c070cdc4caa1fa93d0d7ac3f9d468bfa27a8-SNAPSHOT</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Replace the current Youtube player dependecy with lavalink's alternative Youtube source (https://github.com/lavalink-devs/youtube-source)

### Purpose
This fixed [the "sign in" issue](https://github.com/jagrosh/MusicBot/issues/1588) for my local bot (single Discord server, bot being hosted on a VM on my LAN). YMMV I would guess, if it's a Youtube denylist thing then it's just a matter of time before my IP is re-denylisted, but we've been running with that for the past week and a half and haven't had issues yet.

### Relevant Issue(s)
This PR closes issue https://github.com/jagrosh/MusicBot/issues/1588
