### PR TITLE
Use shell comparsion in run script

### DIFF
--- a/scripts/run_jmusicbot.sh
+++ b/scripts/run_jmusicbot.sh
@@ -9,7 +9,7 @@ DOWNLOAD=true
 LOOP=true
 
 download() {
-    if [ $DOWNLOAD == true ]; then
+    if [ $DOWNLOAD = true ]; then
         URL=$(curl -s https://api.github.com/repos/jagrosh/MusicBot/releases/latest \
            | grep -i "browser_download_url.*\.jar" \
            | sed 's/.*\(http.*\)"/\1/')


### PR DESCRIPTION
### This pull request...
  - [X] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This pull requests ensure that the script will actually work with a POSIX-compliant shell such as sh.

### Purpose
This script does not work on a Linux system in `sh` since == seems to be an extra feature in bash.

One could set the shebang line to `/bin/bash` as well, but staying within shell should be more universal.

### Relevant Issue(s)
None that I know off.