### PR TITLE
Add User-Agent Header to Jsoup Connections in Transforms

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/TransformativeAudioSourceManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/TransformativeAudioSourceManager.java
@@ -67,7 +67,7 @@ public class TransformativeAudioSourceManager extends YoutubeAudioSourceManager
         try
         {
             String url = ar.identifier.replaceAll(regex, replacement);
-            Document doc = Jsoup.connect(url).get();
+            Document doc = Jsoup.connect(url).userAgent("Mozilla").get();
             String value = doc.selectFirst(selector).ownText();
             String formattedValue = String.format(format, value);
             return super.loadItem(apm, new AudioReference(formattedValue, null));


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
In transforms, currently a source's url is fetched without specifying user-agent headers. This small PR adds `.userAgent("Mozilla")` to the line fetching the `Document` of the url through the Jsoup connection. I hardcoded the value as I saw [elsewhere in the codebase](https://github.com/jagrosh/MusicBot/blob/859e5c5862decf433f8face5eaca3372d7d27b22/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java#L107) doing the same practice. This may be improved by allowing the user-agent to be specified in the configs as part of the transform.

### Purpose
When fetching sources in transforms, some servers may block (e.g. 403 Forbidden) due to missing user-agent headers. To fix, set the user-agent to "Mozilla" for the Jsoup connection before fetching the website. 
This allows roundabout loading from sources that block requests with missing user-agent headers to work.*

*Assuming they accept "Mozilla" as a valid user-agent header. For the source I'm using, it does.

### Relevant Issue(s)
N/A (not sure if I should have created an issue first)
