### PR TITLE
Hotfix: uses oauth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.5.2</version>
+            <version>1.7.1</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -51,6 +51,7 @@ public class PlayerManager extends DefaultAudioPlayerManager
 
         YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
         yt.setPlaylistPageCount(bot.getConfig().getMaxYTPlaylistPages());
+        yt.useOauth2(null, false);
         registerSourceManager(yt);
 
         registerSourceManager(SoundCloudAudioSourceManager.createDefault());


### PR DESCRIPTION
Quick fix for an issue #1588 that worked for me. Feel free to merge it if it's useful for ya. I suppose if you wanted it be done professional-like you'd add another GUI window for this and explain everything to the user. People running this in their VMs would still need to see the logs anyway to do this. The documentation on the website has to be updated, unless you figure out any other way to do this more efficiently, but I doubt you can as google themselves supply the code and you have to enter it specifically on their website.

In this case I just tailed the logs with:
`sudo journalctl -u JMusicBot -n 100`

Saw the log:
>  [YoutubeOauth2Handler]: ==================================================
> [YoutubeOauth2Handler]: !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
> [YoutubeOauth2Handler]: OAUTH INTEGRATION: To give youtube-source access to your account, go to 
> https://www.google.com/device and enter code XXXXXXXXXX
 [YoutubeOauth2Handler]: !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
 [YoutubeOauth2Handler]: ==================================================

Went to the website, entered the code. The bot now works. I didn't test much, but everything looks fine.
