### PR TITLE
Updated JDA-Utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.json
 *.txt
 nb*.xml
+dockerfile

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.5.2</version>
+            <version>1.8.3</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,11 @@
             <artifactId>JDA</artifactId>
             <version>4.4.1_353</version>
         </dependency>
-        <dependency>
-            <groupId>com.jagrosh</groupId>
-            <artifactId>jda-utilities</artifactId>
-            <version>3.0.5</version>
-            <type>pom</type>
-        </dependency>
+	<dependency>
+		<groupId>com.github.Nagami-Yukki</groupId>
+		<artifactId>JDA-Utilities</artifactId>
+		<version>1.0</version>
+	</dependency>
 
         <!-- Music Dependencies -->
         <dependency>


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Updated JDA-Utilities in accordance with the fix provided in #1700

### Purpose
Fixes the issue where JDA-Utilities dependency is missing, making the jar unable to be built in maven. This PR also allows other contributors/people to build the project on their own.

### Relevant Issue(s)
This PR closes issue #1700 
