### PR TITLE
QoL Dev Build/Snapshot Builds Disable DM Bot.

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/Listener.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Listener.java
@@ -71,17 +71,22 @@ public class Listener extends ListenerAdapter
         });
         if(bot.getConfig().useUpdateAlerts())
         {
-            bot.getThreadpool().scheduleWithFixedDelay(() -> 
+            bot.getThreadpool().scheduleWithFixedDelay(() ->
             {
                 try
                 {
                     User owner = bot.getJDA().retrieveUserById(bot.getConfig().getOwnerId()).complete();
                     String currentVersion = OtherUtil.getCurrentVersion();
                     String latestVersion = OtherUtil.getLatestVersion();
-                    if(latestVersion!=null && !currentVersion.equalsIgnoreCase(latestVersion))
+                    if(latestVersion != null && !currentVersion.equalsIgnoreCase(latestVersion))
                     {
-                        String msg = String.format(OtherUtil.NEW_VERSION_AVAILABLE, currentVersion, latestVersion);
-                        owner.openPrivateChannel().queue(pc -> pc.sendMessage(msg).queue());
+                        // Check if the current version is a snapshot build
+                        if (!currentVersion.toLowerCase().contains("snapshot"))
+                        {
+                            String msg = String.format(OtherUtil.NEW_VERSION_AVAILABLE, currentVersion, latestVersion);
+                            owner.openPrivateChannel().queue(pc -> pc.sendMessage(msg).queue());
+                        }
+                        // If it's a snapshot build, we don't send the message because who thought sending a dm message on dev builds?? oh wait..
                     }
                 }
                 catch(Exception ignored) {} // ignored

--- a/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/OtherUtil.java
@@ -160,16 +160,22 @@ public class OtherUtil
             prompt.alert(Prompt.Level.WARNING, "Java Version", 
                     "It appears that you may not be using a supported Java version. Please use 64-bit java.");
     }
-    
+
     public static void checkVersion(Prompt prompt)
     {
         // Get current version number
         String version = getCurrentVersion();
-        
+
+        // Check if it's a snapshot version
+        if (version.toLowerCase().contains("snapshot")) {
+            // If it's a snapshot/Dev Build, This should ignore / stop the bot from sending messages to owner...
+            return;
+        }
+
         // Check for new version
         String latestVersion = getLatestVersion();
-        
-        if(latestVersion!=null && !latestVersion.equals(version))
+
+        if(latestVersion != null && !latestVersion.equals(version))
         {
             prompt.alert(Prompt.Level.WARNING, "JMusicBot Version", String.format(NEW_VERSION_AVAILABLE, version, latestVersion));
         }


### PR DESCRIPTION
### This pull request...
  - [-] Fixes a bug
  - [~] Introduces a new feature
  - [-] Improves an existing feature
  - [✓] Boosts code quality or performance

### Description
Disables Bot DMing Owner Version Annoyance when Dealing with Snapshot builds / Dev Builds.


### Purpose
When Dealing with Constant Stop and Starts. The Bot will always send a message on Ready which is annoying. So this checks if the build is  = Snapshot then dont send a dm.

### Relevant Issue(s)
Unknown.
