### PR TITLE
Add YouTube PO token & IP rotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,33 @@
             <artifactId>jsoup</artifactId>
             <version>1.15.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.27.0</version>
+            <!-- https://github.com/SeleniumHQ/selenium/issues/13791 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-devtools-v85</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-devtools-v129</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-devtools-v130</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+
+
 
         <!-- Testing Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.8.3</version>
+            <version>1.11.1</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,22 +45,21 @@
             <version>4.4.1_353</version>
         </dependency>
         <dependency>
-            <groupId>com.jagrosh</groupId>
-            <artifactId>jda-utilities</artifactId>
-            <version>3.0.5</version>
-            <type>pom</type>
+            <groupId>com.github.JDA-Applications</groupId>
+            <artifactId>JDA-Utilities</artifactId>
+            <version>c16a4b264b</version>
         </dependency>
 
         <!-- Music Dependencies -->
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.5.2</version>
+            <version>1.8.3</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
             <version>2.2.2</version>
         </dependency>
         <dependency>
+            <groupId>dev.arbjerg</groupId>
+            <artifactId>lavaplayer-ext-youtube-rotator</artifactId>
+            <version>2.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
             <version>1.8.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.11.4</version>
+            <version>1.11.5</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,17 @@
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer-ext-youtube-rotator</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.12.0</version>
+            <version>1.13.0</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.2</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.4</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.27.0</version>
+            <version>4.30.0</version>
             <!-- https://github.com/SeleniumHQ/selenium/issues/13791 -->
             <exclusions>
                 <exclusion>
@@ -105,11 +105,11 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-devtools-v129</artifactId>
+                    <artifactId>selenium-devtools-v132</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-devtools-v130</artifactId>
+                    <artifactId>selenium-devtools-v133</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.11.5</version>
+            <version>1.12.0</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>

--- a/src/main/java/com/jagrosh/jmusicbot/Bot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Bot.java
@@ -56,7 +56,7 @@ public class Bot
         this.settings = settings;
         this.playlists = new PlaylistLoader(config);
         this.threadpool = Executors.newSingleThreadScheduledExecutor();
-        this.players = new PlayerManager(this);
+        this.players = new PlayerManager(this, config);
         this.players.init();
         this.nowplaying = new NowplayingHandler(this);
         this.nowplaying.init();

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -41,7 +41,7 @@ public class BotConfig
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji,
-            evalEngine;
+            ytPoToken, ytVisitorData, evalEngine;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private int maxYTPlaylistPages;
@@ -96,6 +96,8 @@ public class BotConfig
             aloneTimeUntilStop = config.getLong("alonetimeuntilstop");
             playlistsFolder = config.getString("playlistsfolder");
             aliases = config.getConfig("aliases");
+            ytPoToken = config.getString("ytpotoken");
+            ytVisitorData = config.getString("ytvisitordata");
             transforms = config.getConfig("transforms");
             skipratio = config.getDouble("skipratio");
             dbots = owner == 113156185389092864L;
@@ -321,6 +323,16 @@ public class BotConfig
     public String getLogLevel()
     {
         return logLevel;
+    }
+
+    public String getYtPoToken()
+    {
+        return ytPoToken.equals("PO_TOKEN_HERE") ? null : ytPoToken;
+    }
+
+    public String getYtVisitorData()
+    {
+        return ytVisitorData.equals("VISITOR_DATA_HERE") ? null : ytVisitorData;
     }
 
     public boolean useEval()

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -18,11 +18,16 @@ package com.jagrosh.jmusicbot;
 import com.jagrosh.jmusicbot.entities.Prompt;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.jagrosh.jmusicbot.utils.TimeUtil;
+import com.jagrosh.jmusicbot.utils.YouTubeUtil;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.IpBlock;
 import com.typesafe.config.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
 
@@ -42,6 +47,8 @@ public class BotConfig
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji,
             ytPoToken, ytVisitorData, evalEngine;
+    private YouTubeUtil.RoutingPlanner ytRoutingPlanner;
+    private List<IpBlock> ytIpBlocks;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private int maxYTPlaylistPages;
@@ -98,6 +105,8 @@ public class BotConfig
             aliases = config.getConfig("aliases");
             ytPoToken = config.getString("ytpotoken");
             ytVisitorData = config.getString("ytvisitordata");
+            ytRoutingPlanner = config.getEnum(YouTubeUtil.RoutingPlanner.class, "ytroutingplanner");
+            ytIpBlocks = config.getStringList("ytipblocks").stream().map(YouTubeUtil::parseIpBlock).collect(Collectors.toList());
             transforms = config.getConfig("transforms");
             skipratio = config.getDouble("skipratio");
             dbots = owner == 113156185389092864L;
@@ -325,16 +334,26 @@ public class BotConfig
         return logLevel;
     }
 
-    public String getYtPoToken()
+    public String getYTPoToken()
     {
         return ytPoToken.equals("PO_TOKEN_HERE") ? null : ytPoToken;
     }
 
-    public String getYtVisitorData()
+    public String getYTVisitorData()
     {
         return ytVisitorData.equals("VISITOR_DATA_HERE") ? null : ytVisitorData;
     }
 
+    public YouTubeUtil.RoutingPlanner getYTRoutingPlanner()
+    {
+        return ytRoutingPlanner;
+    }
+    
+    public List<IpBlock> getYTIpBlocks()
+    {
+        return ytIpBlocks;
+    }
+    
     public boolean useEval()
     {
         return useEval;

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -46,10 +46,10 @@ public class BotConfig
     private Path path = null;
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji,
-            ytPoToken, ytVisitorData, evalEngine;
+            chromePath, chromeDriverPath, evalEngine;
     private YouTubeUtil.RoutingPlanner ytRoutingPlanner;
     private List<IpBlock> ytIpBlocks;
-    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
+    private boolean stayInChannel, songInGame, npImages, updatealerts, chromeHeadless, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private int maxYTPlaylistPages;
     private double skipratio;
@@ -103,8 +103,9 @@ public class BotConfig
             aloneTimeUntilStop = config.getLong("alonetimeuntilstop");
             playlistsFolder = config.getString("playlistsfolder");
             aliases = config.getConfig("aliases");
-            ytPoToken = config.getString("ytpotoken");
-            ytVisitorData = config.getString("ytvisitordata");
+            chromePath = config.getString("chromepath");
+            chromeDriverPath = config.getString("chromedriverpath");
+            chromeHeadless = config.getBoolean("chromeheadless");
             ytRoutingPlanner = config.getEnum(YouTubeUtil.RoutingPlanner.class, "ytroutingplanner");
             ytIpBlocks = config.getStringList("ytipblocks").stream().map(YouTubeUtil::parseIpBlock).collect(Collectors.toList());
             transforms = config.getConfig("transforms");
@@ -334,14 +335,19 @@ public class BotConfig
         return logLevel;
     }
 
-    public String getYTPoToken()
+    public String getChromePath()
     {
-        return ytPoToken.equals("PO_TOKEN_HERE") ? null : ytPoToken;
+        return chromePath.equals("AUTO") ? null : chromePath;
     }
 
-    public String getYTVisitorData()
+    public String getChromeDriverPath()
     {
-        return ytVisitorData.equals("VISITOR_DATA_HERE") ? null : ytVisitorData;
+        return chromeDriverPath.equals("AUTO") ? null : chromeDriverPath;
+    }
+    
+    public boolean getChromeHeadless()
+    {
+        return chromeHeadless;
     }
 
     public YouTubeUtil.RoutingPlanner getYTRoutingPlanner()

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Level;
 
+import static com.jagrosh.jmusicbot.utils.YouTubeUtil.GetPoTokenAndVisitorData;
+
 /**
  *
  * @author John Grosh (jagrosh)
@@ -166,6 +168,8 @@ public class JMusicBot
                     + "attempting to connect, please make sure you're connected to the internet");
             System.exit(1);
         }
+
+        GetPoTokenAndVisitorData(config.getChromePath(), config.getChromeDriverPath(), config.getChromeHeadless());
     }
     
     private static CommandClient createCommandClient(BotConfig config, SettingsManager settings, Bot bot)

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -60,9 +60,6 @@ public class PlayerManager extends DefaultAudioPlayerManager
     public void init()
     {
         TransformativeAudioSourceManager.createTransforms(bot.getConfig().getTransforms()).forEach(t -> registerSourceManager(t));
-
-        if (config.getYTPoToken() != null && config.getYTVisitorData() != null)
-            Web.setPoTokenAndVisitorData(config.getYTPoToken(), config.getYTVisitorData());
         
         YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
         if (config.getYTRoutingPlanner() != YouTubeUtil.RoutingPlanner.NONE)

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.audio;
 
 import com.dunctebot.sourcemanagers.DuncteBotSources;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.BotConfig;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerRegistry;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -30,6 +31,7 @@ import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceM
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.clients.Web;
 import net.dv8tion.jda.api.entities.Guild;
 
 /**
@@ -39,16 +41,21 @@ import net.dv8tion.jda.api.entities.Guild;
 public class PlayerManager extends DefaultAudioPlayerManager
 {
     private final Bot bot;
-    
-    public PlayerManager(Bot bot)
+    private final BotConfig config;
+
+    public PlayerManager(Bot bot, BotConfig config)
     {
         this.bot = bot;
+        this.config = config;
     }
     
     public void init()
     {
         TransformativeAudioSourceManager.createTransforms(bot.getConfig().getTransforms()).forEach(t -> registerSourceManager(t));
 
+        if (config.getYtPoToken() != null && config.getYtVisitorData() != null)
+            Web.setPoTokenAndVisitorData(config.getYtPoToken(), config.getYtVisitorData());
+        
         YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
         yt.setPlaylistPageCount(bot.getConfig().getMaxYTPlaylistPages());
         registerSourceManager(yt);

--- a/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
@@ -1,0 +1,46 @@
+package com.jagrosh.jmusicbot.utils;
+
+import com.sedmelluq.lava.extensions.youtuberotator.planner.*;
+import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.IpBlock;
+import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block;
+import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
+
+import java.util.List;
+
+public class YouTubeUtil {
+    public enum RoutingPlanner {
+        NONE,
+        ROTATE_ON_BAN,
+        LOAD_BALANCE,
+        NANO_SWITCH,
+        ROTATING_NANO_SWITCH
+    }
+    
+    public static IpBlock parseIpBlock(String cidr) {
+        if (Ipv6Block.isIpv6CidrBlock(cidr))
+            return new Ipv6Block(cidr);
+
+        if (Ipv4Block.isIpv4CidrBlock(cidr))
+            return new Ipv4Block(cidr);
+        
+        throw new IllegalArgumentException("Could not parse CIDR " + cidr);
+    }
+    
+    public static AbstractRoutePlanner createRouterPlanner(RoutingPlanner routingPlanner, List<IpBlock> ipBlocks) {
+        
+        switch (routingPlanner) {
+            case NONE:
+                return null;
+            case ROTATE_ON_BAN:
+                return new RotatingIpRoutePlanner(ipBlocks);
+            case LOAD_BALANCE:
+                return new BalancingIpRoutePlanner(ipBlocks);
+            case NANO_SWITCH:
+                return new NanoIpRoutePlanner(ipBlocks, true);
+            case ROTATING_NANO_SWITCH:
+                return new RotatingNanoIpRoutePlanner(ipBlocks);
+            default:
+                throw new IllegalArgumentException("Unknown RoutingPlanner value provided");
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
@@ -158,7 +158,7 @@ public class YouTubeUtil {
                 interceptorFuture.complete(e);
             }
 
-            return next.execute(req)    ;
+            return next.execute(req);
         });
 
         //

--- a/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
@@ -158,7 +158,7 @@ public class YouTubeUtil {
                 interceptorFuture.complete(e);
             }
 
-            return next.execute(req);
+            return next.execute(req)    ;
         });
 
         //
@@ -181,7 +181,8 @@ public class YouTubeUtil {
 
 
         } catch (Exception e) {
-            LOGGER.error("Failed to obtain PO token for YouTube playback", e);
+            LOGGER.error("Failed to obtain PO token for YouTube playback: {}", e.getMessage());
+            LOGGER.debug("Exception:", e);
         } finally {
             interceptor.close();
             // Only quit the browser when not in headless mode. Helps with troubleshooting.

--- a/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/YouTubeUtil.java
@@ -4,10 +4,34 @@ import com.sedmelluq.lava.extensions.youtuberotator.planner.*;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.IpBlock;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
+import dev.lavalink.youtube.clients.Web;
+import org.json.JSONObject;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
+import org.openqa.selenium.devtools.NetworkInterceptor;
+import org.openqa.selenium.os.ExecutableFinder;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.Filter;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 public class YouTubeUtil {
+    private final static Logger LOGGER = LoggerFactory.getLogger(YouTubeUtil.class);
+    
     public enum RoutingPlanner {
         NONE,
         ROTATE_ON_BAN,
@@ -41,6 +65,128 @@ public class YouTubeUtil {
                 return new RotatingNanoIpRoutePlanner(ipBlocks);
             default:
                 throw new IllegalArgumentException("Unknown RoutingPlanner value provided");
+        }
+    }
+
+    public static void GetPoTokenAndVisitorData(String userChromePath, String userChromeDriverPath, boolean headless)
+    {
+        //
+        // 1. Find a Chrome install & launch the WebDriver
+        //
+        WebDriverManager wdm = WebDriverManager.chromedriver();
+        if (userChromePath != null) {
+            wdm.browserVersionDetectionCommand(userChromePath + " --version");
+        }
+        else if (wdm.getBrowserPath().isEmpty())
+        {
+            // try finding a Chromium browser instead (Linux users usually install Chromium instead of Google Chrome)
+            wdm = WebDriverManager.chromiumdriver();
+            if (wdm.getBrowserPath().isEmpty()) {
+                LOGGER.error("Could not obtain a PO token for YouTube playback, because no Chrome browser could be found. Please install Google Chrome or Chromium!");
+                return;
+            }
+        }
+        if (userChromeDriverPath == null)
+            // Automatically download & set up ChromeDriver for the Chrome/Chromium version that the user has installed
+            wdm.setup();
+        else {
+            // Find & use the ChromeDriver executable the user provided
+            String path = new ExecutableFinder().find(userChromeDriverPath);
+            if (path == null) {
+                LOGGER.error("Could not obtain a PO token for YouTube playback, because the specified ChromeDriver could not be found. " +
+                        "Please check your config's value of the chromedriverpath, or set it to \"AUTO\" to have JMusicBot automatically download ChromeDriver");
+                return;
+            }
+            LOGGER.info("Using ChromeDriver at {}", path);
+            System.setProperty("webdriver.chrome.driver", path);
+        }
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+
+        chromeOptions.setBinary(userChromePath != null ? userChromePath : wdm.getBrowserPath().get().toString());
+
+        if (!headless)
+            chromeOptions.addArguments("--auto-open-devtools-for-tabs");
+        else
+            chromeOptions.addArguments("--headless=new");
+
+        ChromeDriverService.Builder chromeDriverBuilder = new ChromeDriverService.Builder();
+        if (LOGGER.isDebugEnabled())
+            chromeDriverBuilder.withLogLevel(ChromiumDriverLogLevel.DEBUG);
+
+        WebDriver driver = new ChromeDriver(chromeDriverBuilder.build(), chromeOptions);
+
+        //
+        // 2. Setup a network interceptor to intercept the player API request & obtain po token and visitor data
+        //
+
+        // as the network interceptor below runs on a different thread, we'll have it notify us on this/current thread
+        // whether retrieving the data failed (completes with the Exception) or succeeded (completes with null)
+        CompletableFuture<Exception> interceptorFuture = new CompletableFuture<>();
+
+        NetworkInterceptor interceptor = new NetworkInterceptor(driver,
+                (Filter) next -> req -> {
+            
+            if (req.getMethod() != HttpMethod.POST || !req.getUri().contains("/youtubei/v1/player"))
+                return next.execute(req);
+    
+            try {
+                String rawBody = Contents.string(req);
+                JSONObject body = new JSONObject(rawBody);
+
+                String visitorData = body
+                        .getJSONObject("context")
+                        .getJSONObject("client")
+                        .getString("visitorData");
+
+                String poToken = body
+                        .getJSONObject("serviceIntegrityDimensions")
+                        .getString("poToken");
+
+
+                LOGGER.info("Successfully retrieved PO token & visitor data for YouTube playback.");
+                LOGGER.debug("PO token: {}", poToken);
+                LOGGER.debug("Visitor Data: {}", visitorData);
+
+                if (poToken.length() < 160)
+                    LOGGER.warn("There is a high chance that the retrieved PO token will not work. Try on a different network.");
+
+                Web.setPoTokenAndVisitorData(poToken, visitorData);
+
+                interceptorFuture.complete(null);
+            } catch (Exception e) {
+                interceptorFuture.complete(e);
+            }
+
+            return next.execute(req);
+        });
+
+        //
+        // 3. Navigate to YouTube & start the player
+        //
+        try {
+            driver.get("https://www.youtube.com/embed/aqz-KE-bpKQ");
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(15));
+            WebElement moviePlayer = driver.findElement(By.cssSelector("#movie_player"));
+            moviePlayer.click();
+
+            try {
+                // Wait for the network interceptor to tell us if it got the data
+                Exception result = interceptorFuture.get(20, TimeUnit.SECONDS);
+                if (result != null)
+                    throw new Exception("Failed to read YouTube player request body", result);
+            } catch (TimeoutException e) {
+                throw new Exception("Timed out waiting for YouTube player request");
+            }
+
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to obtain PO token for YouTube playback", e);
+        } finally {
+            interceptor.close();
+            // Only quit the browser when not in headless mode. Helps with troubleshooting.
+            if (headless)
+                driver.quit();
         }
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -200,11 +200,26 @@ aliases {
 loglevel = info
 
 
-// This sets the "Proof of Origin Token" and visitor data to use when playing back YouTube videos.
-// It is recommend to obtain a PO token to avoid getting IP banned from YouTube.
+// This sets the executable path of where a Chrome or Chromium installation is located JMusicBot can use.
+// JMusicBot may launch a web browser to get around anti-bot checks.
+// Set this to "AUTO" to make JMusicBot attempt to find a Chrome/Chromium installation itself.
 
-ytpotoken = "PO_TOKEN_HERE"
-ytvisitordata = "VISITOR_DATA_HERE"
+chromepath = "AUTO"
+
+
+// This sets the executable path of where a ChromeDriver installation is located JMusicBot can use.
+// Set this to "AUTO" to make JMusicBot automatically download the ChromeDriver version
+// which matches the installed Chrome version.
+
+chromedriverpath = "AUTO"
+
+
+// This sets whether JMusicBot should launch Chrome/Chromium instances without a GUI.
+// It is recommended to leave this set to true.
+// If set to false, JMusicBot will not close the browser automatically (even when finished)
+// and will automatically open DevTools for troubleshooting purposes.
+
+chromeheadless = true
 
 
 // This configures the routing planner to use for IP rotation on YouTube.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -200,6 +200,13 @@ aliases {
 loglevel = info
 
 
+// This sets the "Proof of Origin Token" and visitor data to use when playing back YouTube videos.
+// It is recommend to obtain a PO token to avoid getting IP banned from YouTube.
+
+ytpotoken = PO_TOKEN_HERE
+ytvisitordata = VISITOR_DATA_HERE
+
+
 // Transforms are used to modify specific play inputs and convert them to different kinds of inputs
 // These are quite complicated to use, and have limited use-cases, but in theory allow for rough
 // whitelists or blacklists, roundabout loading from some sources, and customization of how things are

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -207,6 +207,27 @@ ytpotoken = PO_TOKEN_HERE
 ytvisitordata = VISITOR_DATA_HERE
 
 
+// This configures the routing planner to use for IP rotation on YouTube.
+// When set, you need to also set an IP block below.
+// The following routing strategies are available:
+// NONE = Disable
+// ROTATE_ON_BAN = Switch IP when currently used address gets banned.
+// LOAD_BALANCE = Selects random IP for each track playback.
+// NANO_SWITCH = Selects IPv6 address based on current nanosecond. Recommended for one /64 IPv6 blocks.
+// ROTATING_NANO_SWITCH = Same as above, but uses the next /64 IPv6 block in the list in case of a ban.
+
+ytroutingplanner = NONE
+
+
+// The IPv4 and IPv6 blocks to use when using the above routing planner.
+// This does nothing when ytroutingplanner is set to none.
+// The list accepts a list of IPv4 or IPv6 CIDR blocks (not a mix of them however)
+// IPv4 example: [ "192.0.2.183", "198.51.100.153/29" ]
+// IPv6 example: [ "2a02:1234:5678:9abc::/64" ]
+
+ytipblocks = [  ]
+
+
 // Transforms are used to modify specific play inputs and convert them to different kinds of inputs
 // These are quite complicated to use, and have limited use-cases, but in theory allow for rough
 // whitelists or blacklists, roundabout loading from some sources, and customization of how things are

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -203,8 +203,8 @@ loglevel = info
 // This sets the "Proof of Origin Token" and visitor data to use when playing back YouTube videos.
 // It is recommend to obtain a PO token to avoid getting IP banned from YouTube.
 
-ytpotoken = PO_TOKEN_HERE
-ytvisitordata = VISITOR_DATA_HERE
+ytpotoken = "PO_TOKEN_HERE"
+ytvisitordata = "VISITOR_DATA_HERE"
 
 
 // This configures the routing planner to use for IP rotation on YouTube.


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description

- Adds config options to provide a PO token & visitor data. Omitting these makes it obvious to YouTube you're a bot & can easily lead to an IP ban.
- Adds IP(v6) rotation in the hopes of reducing chances of getting IP bans.

Unfortunately the setup for both are fairly complicated. I'm hoping that obtaining a PO token bit can be automated (thus this being a draft PR). IPv6 rotation is even more complicated & hosting-dependent, so this is probably reserved for power users.


### Purpose
Allows for (semi-)reliable YouTube playback again

### Relevant Issue(s)

Somewhat fixes #1588

Somewhat fixes #1682

### TODO

- [ ] Document or automate PO token retrieval.
  - Lavalink's [`youtube-source` README](<https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#using-a-potoken>) suggests to run the [`youtube-trusted-session-generator`](<https://github.com/iv-org/youtube-trusted-session-generator>) python script/docker image to generate these.
  - Alternatively, `yt-dlp`'s wiki has a guide on [manually retrieving PO tokens](<https://github.com/yt-dlp/yt-dlp/wiki/Extractors#manually-acquiring-a-po-token-from-a-browser-for-use-when-logged-out>)
    - In step 6, instead of exporting cookies, I believe you can extract the visitor id in the player request at `context.client.visitorData`, im not sure if its the identical though i have to yet double check.
    - In step 7, instead of using yt-dlp you put the PO token & visitor data in the config.txt, of course
- [ ] Document IPv6 rotation.
  - Lavalink's [RoutePlanner](<https://lavalink.dev/configuration/routeplanner.html>) and [IPv6](<https://lavalink.dev/configuration/ipv6/index.html>) docs pages are a great reference for this.
- [ ] Some cleanup & fixing inconsistencies