### PR TITLE
please disregard I opened on accident

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Rename jar
         run: mv target/*-All.jar JMusicBot-${{ github.event.inputs.version_number }}.jar
       - name: Upload jar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar
           path: JMusicBot-${{ github.event.inputs.version_number }}.jar
@@ -45,7 +45,7 @@ jobs:
     needs: build_jar
     steps:
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
           cache: 'none'
       - name: Set Version
-        uses: datamonsters/replace-action@v2
+        uses: datamonsters/replace-action@v4
         with:
           files: 'pom.xml'
           replacements: 'Snapshot=${{ github.event.inputs.version_number }}'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: 'none'
+          cache: 'maven'
       - name: Set Version
         uses: datamonsters/replace-action@v2
         with:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'temurin'
           cache: 'none'
       - name: Set Version
-        uses: datamonsters/replace-action@v4
+        uses: datamonsters/replace-action@v2
         with:
           files: 'pom.xml'
           replacements: 'Snapshot=${{ github.event.inputs.version_number }}'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: 'maven'
+          cache: 'none'
       - name: Set Version
         uses: datamonsters/replace-action@v2
         with:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'temurin'
+          distribution: 'adopt'
           cache: 'maven'
       - name: Set Version
         uses: datamonsters/replace-action@v2

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
-          cache: maven
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Set Version
         uses: datamonsters/replace-action@v2
         with:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          cache: 'maven'
+          cache: maven
       - name: Set Version
         uses: datamonsters/replace-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target/
 /Playlists/
 /test/
+.idea
 *.json
 *.txt
 nb*.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use an OpenJDK 11 image as the base image
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the JAR file and the config file into the container
+COPY MusicBot.jar /app/MusicBot.jar
+COPY config.txt /app/config.txt
+
+# Expose any port needed by the bot (optional, replace 8080 if required)
+# EXPOSE 8080
+
+# Run the JAR file with the -Dnogui=true argument
+CMD ["java", "-Dnogui=true", "-jar", "/app/MusicBot.jar", "config.txt"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Unofficial JMusicBot update (Forked from: https://github.com/d-pacheco/MusicBot)
+Compiled using Github Actions
+
+### To enable Oauth
+- In your bot folder, edit "config.txt" and add `youtubeoauth2=true` to enable Youtube oauth.
+- USE A BURNER GOOGLE ACCOUNT AS YOU MAY GET BANNED IN THE WORSE CASE.
+
 <img align="right" src="https://i.imgur.com/zrE80HY.png" height="200" width="200">
 
 # JMusicBot

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             </snapshots>
         </repository>
         <repository>
+            <id>chewtils-snapshots</id>
+            <url>https://m2.chew.pro/snapshots/</url>
+        </repository>
+        <repository>
             <id>m2.duncte123.dev</id>
             <name>m2-duncte123</name>
             <url>https://m2.duncte123.dev/releases</url>
@@ -42,25 +46,34 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.4.1_353</version>
+            <version>5.6.1</version>
+        </dependency>
+        <!-- Chewtils modules (drop-in for JDA-Utilities) -->
+        <dependency>
+            <groupId>pw.chew</groupId>
+            <artifactId>jda-chewtils-commons</artifactId>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.jagrosh</groupId>
-            <artifactId>jda-utilities</artifactId>
-            <version>3.0.5</version>
-            <type>pom</type>
+            <groupId>pw.chew</groupId>
+            <artifactId>jda-chewtils-command</artifactId>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
-
+        <dependency>
+            <groupId>pw.chew</groupId>
+            <artifactId>jda-chewtils-menu</artifactId>
+            <version>2.0-SNAPSHOT</version>
+        </dependency>
         <!-- Music Dependencies -->
         <dependency>
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.5.2</version>
+            <version>1.13.5</version>
         </dependency>
 	<dependency>
 	    <groupId>com.github.jagrosh</groupId>
@@ -71,36 +84,46 @@
             <groupId>com.dunctebot</groupId>
             <artifactId>sourcemanagers</artifactId>
             <version>1.9.0</version>
+        <exclusions>
+                <exclusion>
+                    <groupId>dev.lavalink.youtube</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sedmelluq</groupId>
+                    <artifactId>lavaplayer-ext-youtube</artifactId>
+                </exclusion>
+        </exclusions>
         </dependency>
 
         <!-- Misc Internal Dependencies -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.5.7</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.2</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
+            <version>1.18.1</version>
         </dependency>
 
         <!-- Testing Dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/jagrosh/jmusicbot/Bot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/Bot.java
@@ -26,6 +26,7 @@ import com.jagrosh.jmusicbot.gui.GUI;
 import com.jagrosh.jmusicbot.playlist.PlaylistLoader;
 import com.jagrosh.jmusicbot.settings.SettingsManager;
 import java.util.Objects;
+import com.jagrosh.jmusicbot.utils.YoutubeOauth2TokenHandler;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
@@ -44,6 +45,7 @@ public class Bot
     private final PlaylistLoader playlists;
     private final NowplayingHandler nowplaying;
     private final AloneInVoiceHandler aloneInVoiceHandler;
+    private final YoutubeOauth2TokenHandler youTubeOauth2TokenHandler;
     
     private boolean shuttingDown = false;
     private JDA jda;
@@ -56,6 +58,8 @@ public class Bot
         this.settings = settings;
         this.playlists = new PlaylistLoader(config);
         this.threadpool = Executors.newSingleThreadScheduledExecutor();
+        this.youTubeOauth2TokenHandler = new YoutubeOauth2TokenHandler();
+        this.youTubeOauth2TokenHandler.init();
         this.players = new PlayerManager(this);
         this.players.init();
         this.nowplaying = new NowplayingHandler(this);
@@ -102,6 +106,11 @@ public class Bot
     public AloneInVoiceHandler getAloneInVoiceHandler()
     {
         return aloneInVoiceHandler;
+    }
+
+    public YoutubeOauth2TokenHandler getYouTubeOauth2Handler()
+    {
+        return youTubeOauth2TokenHandler;
     }
     
     public JDA getJDA()

--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -42,7 +42,7 @@ public class BotConfig
     private String token, prefix, altprefix, helpWord, playlistsFolder, logLevel,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji,
             evalEngine;
-    private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
+    private boolean youtubeOauth2, stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
     private long owner, maxSeconds, aloneTimeUntilStop;
     private int maxYTPlaylistPages;
     private double skipratio;
@@ -84,6 +84,7 @@ public class BotConfig
             searchingEmoji = config.getString("searching");
             game = OtherUtil.parseGame(config.getString("game"));
             status = OtherUtil.parseStatus(config.getString("status"));
+            youtubeOauth2 = config.getBoolean("youtubeoauth2");
             stayInChannel = config.getBoolean("stayinchannel");
             songInGame = config.getBoolean("songinstatus");
             npImages = config.getBoolean("npimages");
@@ -291,6 +292,11 @@ public class BotConfig
     public String getHelp()
     {
         return helpWord;
+    }
+    
+    public boolean useYoutubeOauth2()
+    {
+        return youtubeOauth2;
     }
     
     public boolean getStay()

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -18,7 +18,6 @@ package com.jagrosh.jmusicbot;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
-import com.jagrosh.jdautilities.examples.command.*;
 import com.jagrosh.jmusicbot.commands.admin.*;
 import com.jagrosh.jmusicbot.commands.dj.*;
 import com.jagrosh.jmusicbot.commands.general.*;
@@ -30,7 +29,6 @@ import com.jagrosh.jmusicbot.settings.SettingsManager;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 import java.awt.Color;
 import java.util.Arrays;
-import javax.security.auth.login.LoginException;
 import net.dv8tion.jda.api.*;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.requests.GatewayIntent;
@@ -47,7 +45,7 @@ import ch.qos.logback.classic.Level;
 public class JMusicBot 
 {
     public final static Logger LOG = LoggerFactory.getLogger(JMusicBot.class);
-    public final static Permission[] RECOMMENDED_PERMS = {Permission.MESSAGE_READ, Permission.MESSAGE_WRITE, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
+    public final static Permission[] RECOMMENDED_PERMS = {Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
                                 Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
     public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES};
@@ -74,7 +72,7 @@ public class JMusicBot
         Prompt prompt = new Prompt("JMusicBot");
         
         // startup checks
-        OtherUtil.checkVersion(prompt);
+        // OtherUtil.checkVersion(prompt);
         OtherUtil.checkJavaVersion(prompt);
         
         // load config
@@ -117,13 +115,12 @@ public class JMusicBot
         try
         {
             JDA jda = JDABuilder.create(config.getToken(), Arrays.asList(INTENTS))
-                    .enableCache(CacheFlag.MEMBER_OVERRIDES, CacheFlag.VOICE_STATE)
-                    .disableCache(CacheFlag.ACTIVITY, CacheFlag.CLIENT_STATUS, CacheFlag.EMOTE, CacheFlag.ONLINE_STATUS)
+                    .enableCache(CacheFlag.VOICE_STATE)
+                    .disableCache(CacheFlag.ACTIVITY, CacheFlag.EMOJI, CacheFlag.ONLINE_STATUS)
                     .setActivity(config.isGameNone() ? null : Activity.playing("loading..."))
                     .setStatus(config.getStatus()==OnlineStatus.INVISIBLE || config.getStatus()==OnlineStatus.OFFLINE 
                             ? OnlineStatus.INVISIBLE : OnlineStatus.DO_NOT_DISTURB)
                     .addEventListeners(client, waiter, new Listener(bot))
-                    .setBulkDeleteSplittingEnabled(true)
                     .build();
             bot.setJDA(jda);
 
@@ -147,13 +144,6 @@ public class JMusicBot
                         + "on https://discord.com/developers/applications/" + jda.getSelfUser().getId() + "/bot");
             }
         }
-        catch (LoginException ex)
-        {
-            prompt.alert(Prompt.Level.ERROR, "JMusicBot", ex + "\nPlease make sure you are "
-                    + "editing the correct config.txt file, and that you have used the "
-                    + "correct token (not the 'secret'!)\nConfig Location: " + config.getConfigLocation());
-            System.exit(1);
-        }
         catch(IllegalArgumentException ex)
         {
             prompt.alert(Prompt.Level.ERROR, "JMusicBot", "Some aspect of the configuration is "
@@ -170,14 +160,6 @@ public class JMusicBot
     
     private static CommandClient createCommandClient(BotConfig config, SettingsManager settings, Bot bot)
     {
-        // instantiate about command
-        AboutCommand aboutCommand = new AboutCommand(Color.BLUE.brighter(),
-                                "a music bot that is [easy to host yourself!](https://github.com/jagrosh/MusicBot) (v" + OtherUtil.getCurrentVersion() + ")",
-                                new String[]{"High-quality music playback", "FairQueue™ Technology", "Easy to host yourself"},
-                                RECOMMENDED_PERMS);
-        aboutCommand.setIsAuthor(false);
-        aboutCommand.setReplacementCharacter("\uD83C\uDFB6"); // 🎶
-        
         // set up the command client
         CommandClientBuilder cb = new CommandClientBuilder()
                 .setPrefix(config.getPrefix())
@@ -187,8 +169,7 @@ public class JMusicBot
                 .setHelpWord(config.getHelp())
                 .setLinkedCacheSize(200)
                 .setGuildSettingsManager(settings)
-                .addCommands(aboutCommand,
-                        new PingCommand(),
+                .addCommands(
                         new SettingsCmd(bot),
                         
                         new LyricsCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
+++ b/src/main/java/com/jagrosh/jmusicbot/JMusicBot.java
@@ -48,7 +48,7 @@ public class JMusicBot
     public final static Permission[] RECOMMENDED_PERMS = {Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
                                 Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
-    public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES};
+    public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.MESSAGE_CONTENT};
     
     /**
      * @param args the command line arguments

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioHandler.java
@@ -36,7 +36,8 @@ import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioTrack;
 import java.nio.ByteBuffer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.audio.AudioSendHandler;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
@@ -118,7 +119,7 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
     
     public boolean isMusicPlaying(JDA jda)
     {
-        return guild(jda).getSelfMember().getVoiceState().inVoiceChannel() && audioPlayer.getPlayingTrack()!=null;
+        return guild(jda).getSelfMember().getVoiceState().inAudioChannel() && audioPlayer.getPlayingTrack()!=null;
     }
     
     public Set<String> getVotes()
@@ -215,14 +216,14 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
 
     
     // Formatting
-    public Message getNowPlaying(JDA jda)
+    public MessageCreateData getNowPlaying(JDA jda)
     {
         if(isMusicPlaying(jda))
         {
             Guild guild = guild(jda);
             AudioTrack track = audioPlayer.getPlayingTrack();
-            MessageBuilder mb = new MessageBuilder();
-            mb.append(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing in "+guild.getSelfMember().getVoiceState().getChannel().getAsMention()+"...**"));
+            MessageCreateBuilder mb = new MessageCreateBuilder();
+            mb.setContent(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing in "+guild.getSelfMember().getVoiceState().getChannel().getAsMention()+"...**"));
             EmbedBuilder eb = new EmbedBuilder();
             eb.setColor(guild.getSelfMember().getColor());
             RequestMetadata rm = getRequestMetadata();
@@ -257,22 +258,22 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
                     + " "+FormatUtil.progressBar(progress)
                     + " `[" + TimeUtil.formatTime(track.getPosition()) + "/" + TimeUtil.formatTime(track.getDuration()) + "]` "
                     + FormatUtil.volumeIcon(audioPlayer.getVolume()));
-            
             return mb.setEmbeds(eb.build()).build();
         }
         else return null;
     }
     
-    public Message getNoMusicPlaying(JDA jda)
+    public MessageCreateData getNoMusicPlaying(JDA jda)
     {
         Guild guild = guild(jda);
-        return new MessageBuilder()
+        return new MessageCreateBuilder()
                 .setContent(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing...**"))
                 .setEmbeds(new EmbedBuilder()
                 .setTitle("No music playing")
                 .setDescription(STOP_EMOJI+" "+FormatUtil.progressBar(-1)+" "+FormatUtil.volumeIcon(audioPlayer.getVolume()))
                 .setColor(guild.getSelfMember().getColor())
-                .build()).build();
+                .build())
+                .build();
     }
 
     public String getStatusEmoji()

--- a/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/NowplayingHandler.java
@@ -27,7 +27,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 
@@ -54,7 +54,7 @@ public class NowplayingHandler
     
     public void setLastNPMessage(Message m)
     {
-        lastNP.put(m.getGuild().getIdLong(), new Pair<>(m.getTextChannel().getIdLong(), m.getIdLong()));
+        lastNP.put(m.getGuild().getIdLong(), new Pair<>(m.getChannel().getIdLong(), m.getIdLong()));
     }
     
     public void clearLastNPMessage(Guild guild)
@@ -81,7 +81,7 @@ public class NowplayingHandler
                 continue;
             }
             AudioHandler handler = (AudioHandler)guild.getAudioManager().getSendingHandler();
-            Message msg = handler.getNowPlaying(bot.getJDA());
+            net.dv8tion.jda.api.utils.messages.MessageCreateData msg = handler.getNowPlaying(bot.getJDA());
             if(msg==null)
             {
                 msg = handler.getNoMusicPlaying(bot.getJDA());
@@ -89,7 +89,8 @@ public class NowplayingHandler
             }
             try 
             {
-                tc.editMessageById(pair.getValue(), msg).queue(m->{}, t -> lastNP.remove(guildId));
+                tc.editMessageById(pair.getValue(), net.dv8tion.jda.api.utils.messages.MessageEditData.fromCreateData(msg))
+                        .queue(m->{}, t -> lastNP.remove(guildId));
             } 
             catch(Exception e) 
             {
@@ -105,7 +106,7 @@ public class NowplayingHandler
         // update bot status if applicable
         if(bot.getConfig().getSongInStatus())
         {
-            if(track!=null && bot.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inVoiceChannel()).count()<=1)
+            if(track!=null && bot.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inAudioChannel()).count()<=1)
                 bot.getJDA().getPresence().setActivity(Activity.listening(track.getInfo().title));
             else
                 bot.resetGame();

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.audio;
 
 import com.dunctebot.sourcemanagers.DuncteBotSources;
 import com.jagrosh.jmusicbot.Bot;
+import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerRegistry;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -31,6 +32,11 @@ import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceMan
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import net.dv8tion.jda.api.entities.Guild;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 
 /**
  *
@@ -38,6 +44,7 @@ import net.dv8tion.jda.api.entities.Guild;
  */
 public class PlayerManager extends DefaultAudioPlayerManager
 {
+    private final static Logger LOGGER = LoggerFactory.getLogger(PlayerManager.class);
     private final Bot bot;
     
     public PlayerManager(Bot bot)
@@ -49,8 +56,7 @@ public class PlayerManager extends DefaultAudioPlayerManager
     {
         TransformativeAudioSourceManager.createTransforms(bot.getConfig().getTransforms()).forEach(t -> registerSourceManager(t));
 
-        YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
-        yt.setPlaylistPageCount(bot.getConfig().getMaxYTPlaylistPages());
+        YoutubeAudioSourceManager yt = setupYoutubeAudioSourceManager();
         registerSourceManager(yt);
 
         registerSourceManager(SoundCloudAudioSourceManager.createDefault());
@@ -66,7 +72,41 @@ public class PlayerManager extends DefaultAudioPlayerManager
 
         DuncteBotSources.registerAll(this, "en-US");
     }
-    
+
+    private YoutubeAudioSourceManager setupYoutubeAudioSourceManager()
+    {
+        YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
+        yt.setPlaylistPageCount(bot.getConfig().getMaxYTPlaylistPages());
+
+        // OAuth2 setup
+        if (bot.getConfig().useYoutubeOauth2())
+        {
+            String token = null;
+            try
+            {
+                token = Files.readString(OtherUtil.getPath("youtubetoken.txt"));
+            }
+            catch (NoSuchFileException e)
+            {
+                /* ignored */
+            }
+            catch (IOException e)
+            {
+                LOGGER.warn("Failed to read YouTube OAuth2 token file: {}", e.getMessage());
+            }
+            LOGGER.debug("Using YouTube OAuth2 refresh token {}", token);
+            try
+            {
+                yt.useOauth2(token, false);
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Failed to authorise with YouTube. If this issue persists, delete the youtubetoken.txt file to reauthorise.", e);
+            }
+        }
+        return yt;
+    }
+
     public Bot getBot()
     {
         return bot;

--- a/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/MusicCommand.java
@@ -21,8 +21,9 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 
 /**
@@ -47,7 +48,7 @@ public abstract class MusicCommand extends Command
     {
         Settings settings = event.getClient().getSettingsFor(event.getGuild());
         TextChannel tchannel = settings.getTextChannel(event.getGuild());
-        if(tchannel!=null && !event.getTextChannel().equals(tchannel))
+        if(tchannel!=null && (event.getChannel()==null || event.getChannel().getIdLong()!=tchannel.getIdLong()))
         {
             try 
             {
@@ -64,11 +65,11 @@ public abstract class MusicCommand extends Command
         }
         if(beListening)
         {
-            VoiceChannel current = event.getGuild().getSelfMember().getVoiceState().getChannel();
+            AudioChannel current = event.getGuild().getSelfMember().getVoiceState().getChannel();
             if(current==null)
                 current = settings.getVoiceChannel(event.getGuild());
             GuildVoiceState userState = event.getMember().getVoiceState();
-            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
+            if(!userState.inAudioChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
             {
                 event.replyError("You must be listening in "+(current==null ? "a voice channel" : current.getAsMention())+" to use that!");
                 return;
@@ -81,7 +82,7 @@ public abstract class MusicCommand extends Command
                 return;
             }
 
-            if(!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel())
+            if(!event.getGuild().getSelfMember().getVoiceState().inAudioChannel())
             {
                 try 
                 {

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -22,7 +22,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 /**
  *
@@ -54,7 +54,9 @@ public class SettcCmd extends AdminCommand
         }
         else
         {
-            List<TextChannel> list = FinderUtil.findTextChannels(event.getArgs(), event.getGuild());
+            List<TextChannel> list = event.getGuild().getTextChannels().stream()
+                    .filter(c -> c.getName().toLowerCase().contains(event.getArgs().toLowerCase()))
+                    .toList();
             if(list.isEmpty())
                 event.reply(event.getClient().getWarning()+" No Text Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SettcCmd.java
@@ -23,6 +23,7 @@ import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -56,7 +57,7 @@ public class SettcCmd extends AdminCommand
         {
             List<TextChannel> list = event.getGuild().getTextChannels().stream()
                     .filter(c -> c.getName().toLowerCase().contains(event.getArgs().toLowerCase()))
-                    .toList();
+                    .collect(Collectors.toList());
             if(list.isEmpty())
                 event.reply(event.getClient().getWarning()+" No Text Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -22,7 +22,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *
@@ -54,7 +54,9 @@ public class SetvcCmd extends AdminCommand
         }
         else
         {
-            List<VoiceChannel> list = FinderUtil.findVoiceChannels(event.getArgs(), event.getGuild());
+            List<VoiceChannel> list = event.getGuild().getVoiceChannels().stream()
+                    .filter(c -> c.getName().toLowerCase().contains(event.getArgs().toLowerCase()))
+                    .toList();
             if(list.isEmpty())
                 event.reply(event.getClient().getWarning()+" No Voice Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/admin/SetvcCmd.java
@@ -23,6 +23,7 @@ import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -56,7 +57,7 @@ public class SetvcCmd extends AdminCommand
         {
             List<VoiceChannel> list = event.getGuild().getVoiceChannels().stream()
                     .filter(c -> c.getName().toLowerCase().contains(event.getArgs().toLowerCase()))
-                    .toList();
+                    .collect(Collectors.toList());;
             if(list.isEmpty())
                 event.reply(event.getClient().getWarning()+" No Voice Channels found matching \""+event.getArgs()+"\"");
             else if (list.size()>1)

--- a/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/general/SettingsCmd.java
@@ -23,10 +23,10 @@ import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *
@@ -48,10 +48,8 @@ public class SettingsCmd extends Command
     protected void execute(CommandEvent event) 
     {
         Settings s = event.getClient().getSettingsFor(event.getGuild());
-        MessageBuilder builder = new MessageBuilder()
-                .append(EMOJI + " **")
-                .append(FormatUtil.filter(event.getSelfUser().getName()))
-                .append("** settings:");
+        MessageCreateBuilder builder = new MessageCreateBuilder()
+                .setContent(EMOJI + " **" + FormatUtil.filter(event.getSelfUser().getName()) + "** settings:");
         TextChannel tchan = s.getTextChannel(event.getGuild());
         VoiceChannel vchan = s.getVoiceChannel(event.getGuild());
         Role role = s.getRole(event.getGuild());
@@ -70,7 +68,7 @@ public class SettingsCmd extends Command
                         + "\nDefault Playlist: " + (s.getDefaultPlaylist() == null ? "None" : "**" + s.getDefaultPlaylist() + "**")
                         )
                 .setFooter(event.getJDA().getGuilds().size() + " servers | "
-                        + event.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inVoiceChannel()).count()
+                        + event.getJDA().getGuilds().stream().filter(g -> g.getSelfMember().getVoiceState().inAudioChannel()).count()
                         + " audio connections", null);
         event.getChannel().sendMessage(builder.setEmbeds(ebuilder.build()).build()).queue();
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/NowplayingCmd.java
@@ -20,7 +20,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
 /**
  *
@@ -41,15 +41,15 @@ public class NowplayingCmd extends MusicCommand
     public void doCommand(CommandEvent event) 
     {
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
-        Message m = handler.getNowPlaying(event.getJDA());
-        if(m==null)
+        MessageCreateData data = handler.getNowPlaying(event.getJDA());
+        if(data==null)
         {
-            event.reply(handler.getNoMusicPlaying(event.getJDA()));
+            event.getChannel().sendMessage(handler.getNoMusicPlaying(event.getJDA())).queue();
             bot.getNowplayingHandler().clearLastNPMessage(event.getGuild());
         }
         else
         {
-            event.reply(m, msg -> bot.getNowplayingHandler().setLastNPMessage(msg));
+            event.getChannel().sendMessage(data).queue(msg -> bot.getNowplayingHandler().setLastNPMessage(msg));
         }
     }
 }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/music/QueueCmd.java
@@ -28,7 +28,8 @@ import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import com.jagrosh.jmusicbot.utils.TimeUtil;
-import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.exceptions.PermissionException;
@@ -75,12 +76,13 @@ public class QueueCmd extends MusicCommand
         List<QueuedTrack> list = ah.getQueue().getList();
         if(list.isEmpty())
         {
-            Message nowp = ah.getNowPlaying(event.getJDA());
-            Message nonowp = ah.getNoMusicPlaying(event.getJDA());
-            Message built = new MessageBuilder()
+            MessageCreateData nowp = ah.getNowPlaying(event.getJDA());
+            MessageCreateData nonowp = ah.getNoMusicPlaying(event.getJDA());
+            MessageCreateData built = new MessageCreateBuilder()
                     .setContent(event.getClient().getWarning() + " There is no music in the queue!")
-                    .setEmbeds((nowp==null ? nonowp : nowp).getEmbeds().get(0)).build();
-            event.reply(built, m -> 
+                    .setEmbeds((nowp==null ? nonowp : nowp).getEmbeds())
+                    .build();
+            event.getChannel().sendMessage(built).queue(m -> 
             {
                 if(nowp!=null)
                     bot.getNowplayingHandler().setLastNPMessage(m);

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/DebugCmd.java
@@ -23,7 +23,8 @@ import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
 import net.dv8tion.jda.api.JDAInfo;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.utils.FileUpload;
 
 /**
  *
@@ -80,7 +81,7 @@ public class DebugCmd extends OwnerCommand
         
         if(event.isFromType(ChannelType.PRIVATE) 
                 || event.getSelfMember().hasPermission(event.getTextChannel(), Permission.MESSAGE_ATTACH_FILES))
-            event.getChannel().sendFile(sb.toString().getBytes(), "debug_information.txt").queue();
+            event.getChannel().sendFiles(FileUpload.fromData(sb.toString().getBytes(), "debug_information.txt")).queue();
         else
             event.reply("Debug Information: " + sb.toString());
     }

--- a/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/owner/EvalCmd.java
@@ -20,7 +20,7 @@ import javax.script.ScriptEngineManager;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
-import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 
 /**
  *

--- a/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
+++ b/src/main/java/com/jagrosh/jmusicbot/settings/Settings.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Collections;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *

--- a/src/main/java/com/jagrosh/jmusicbot/utils/FormatUtil.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/FormatUtil.java
@@ -18,9 +18,10 @@ package com.jagrosh.jmusicbot.utils;
 import com.jagrosh.jmusicbot.audio.RequestMetadata.UserInfo;
 import java.util.List;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *

--- a/src/main/java/com/jagrosh/jmusicbot/utils/YoutubeOauth2TokenHandler.java
+++ b/src/main/java/com/jagrosh/jmusicbot/utils/YoutubeOauth2TokenHandler.java
@@ -1,0 +1,87 @@
+package com.jagrosh.jmusicbot.utils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+import java.nio.file.Files;
+
+/**
+ * A logback turbo filter, used retrieve the YouTube OAuth2 refresh token that gets logged once authorized with YouTube.
+ *
+ * @author Michaili K. <git@michaili.dev>
+ */
+public class YoutubeOauth2TokenHandler extends TurboFilter {
+    public final static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(YoutubeOauth2TokenHandler.class);
+    private Data data;
+
+
+    public void init()
+    {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.addTurboFilter(this);
+    }
+
+    public Data getData()
+    {
+        return data;
+    }
+
+    @Override
+    public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t)
+    {
+        if (!logger.getName().equals("dev.lavalink.youtube.http.YoutubeOauth2Handler"))
+            return FilterReply.NEUTRAL;
+
+        if (format.equals("OAUTH INTEGRATION: To give youtube-source access to your account, go to {} and enter code {}"))
+        {
+            this.data = new Data((String) params[0], (String) params[1]);
+            return FilterReply.NEUTRAL;
+        }
+        if (format.equals("OAUTH INTEGRATION: Token retrieved successfully. Store your refresh token as this can be reused. ({})"))
+        {
+            LOGGER.info("Authorization successful & retrieved token! Storing the token in {}", OtherUtil.getPath("youtubetoken.txt").toAbsolutePath());
+            try
+            {
+                Files.write(OtherUtil.getPath("youtubetoken.txt"), params[0].toString().getBytes());
+            }
+            catch (Exception e)
+            {
+                LOGGER.error(
+                        "Failed to write the YouTube OAuth2 refresh token to storage! You will need to authorize again on the next reboot",
+                        e
+                );
+            }
+            return FilterReply.DENY;
+        }
+
+        return FilterReply.NEUTRAL;
+    }
+
+    public static class Data
+    {
+        private final String authorisationUrl;
+        private final String code;
+
+        private Data(String authorisationUrl, String code)
+        {
+            this.authorisationUrl = authorisationUrl;
+            this.code = code;
+        }
+
+        public String getCode()
+        {
+            return code;
+        }
+
+        public String getAuthorisationUrl()
+        {
+            return authorisationUrl;
+        }
+    }
+
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,5 +13,5 @@
     <root level="INFO">
         <appender-ref ref="Simple"/>
     </root>
-
+    
 </configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -48,6 +48,13 @@ game = "DEFAULT"
 status = ONLINE
 
 
+// If you set this to true, the bot will use a Google account to play back YouTube tracks
+// Once enabled, instructions for logging in will be written to the console
+// This is only needed if you are experiencing issues with YouTube playback
+// DO NOT use your main Google account! Use an alternative account
+
+youtubeoauth2=false
+
 // If you set this to true, the bot will list the title of the song it is currently playing in its
 // "Playing" status. Note that this will ONLY work if the bot is playing music on ONE guild;
 // if the bot is playing on multiple guilds, this will not work.


### PR DESCRIPTION
This PR extends the updates from ahson01 PR "Update to JDA 5.6.1, Add YouTube OAuth2 support, Transform sources, and expanded audio managers" [1836](https://github.com/jagrosh/MusicBot/pull/1836)

This pull request builds off that version to fix several issues causing the build to fail and allowing the bot to read messages within Discord.

### Key Changes
Fixes issues within the yml after Github's deprecation of v3: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions

Sets these versions to v4

Fixes an issue caused by Discord where MESSAGE_CONTENT needs to be explicitly allowed in the music bots GatewayIntent

